### PR TITLE
[FEAT] - update sync flow for CVD and Vitals to sync data from server

### DIFF
--- a/app/src/main/java/com/heartcare/agni/data/local/repository/appointment/AppointmentRepositoryImpl.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/repository/appointment/AppointmentRepositoryImpl.kt
@@ -21,7 +21,6 @@ class AppointmentRepositoryImpl @Inject constructor(
         startOfDay: Long,
         endOfDay: Long
     ): List<AppointmentResponseLocal> {
-        // For facility queue, only return facility appointments
         return appointmentDao.getAppointmentsByDate(startOfDay, endOfDay).map { it.toAppointmentResponseLocal() }
             .groupBy { it.patientId }
             .map { (_, appointments) -> appointments.minBy { it.createdOn } }
@@ -38,12 +37,13 @@ class AppointmentRepositoryImpl @Inject constructor(
     override suspend fun getAppointmentsOfPatient(
         patientId: String
     ): List<AppointmentResponseLocal> {
-        // Aggregate for a unified history view
-        val facility = appointmentDao.getAppointmentsOfPatient(patientId).map { it.toAppointmentResponseLocal() }
-        val campaign = campaignAppointmentDao.getAppointmentsOfPatient(patientId).map { it.toAppointmentResponseLocal() }
-        
-        return (facility + campaign).groupBy { it.slot.start.toddMMMyyyy() }
-            .map { (_, appointment) -> appointment.minBy { it.createdOn } }
+        return appointmentDao.getAppointmentsOfPatient(patientId).map {
+            it.toAppointmentResponseLocal()
+        }.groupBy {
+            it.slot.start.toddMMMyyyy()
+        }.map { (_, appointment) ->
+            appointment.minBy { it.createdOn }
+        }
     }
 
     override suspend fun getAppointmentsOfPatientByDate(
@@ -51,14 +51,7 @@ class AppointmentRepositoryImpl @Inject constructor(
         startOfDay: Long,
         endOfDay: Long
     ): AppointmentResponseLocal? {
-        // Check facility first
-        val facility = appointmentDao.getAppointmentOfPatientByDate(patientId, startOfDay, endOfDay)
-            .minByOrNull { it.createdOn }
-            ?.toAppointmentResponseLocal()
-        if (facility != null) return facility
-
-        // Then campaign
-        return campaignAppointmentDao.getAppointmentOfPatientByDate(patientId, startOfDay, endOfDay)
+        return appointmentDao.getAppointmentOfPatientByDate(patientId, startOfDay, endOfDay)
             .minByOrNull { it.createdOn }
             ?.toAppointmentResponseLocal()
     }
@@ -86,9 +79,7 @@ class AppointmentRepositoryImpl @Inject constructor(
         status: String
     ): List<AppointmentResponseLocal> {
         val facility = appointmentDao.getAppointmentsOfPatientByStatus(patientId, status).map { it.toAppointmentResponseLocal() }
-        val campaign = campaignAppointmentDao.getAppointmentsOfPatientByStatus(patientId, status).map { it.toAppointmentResponseLocal() }
-        
-        return (facility + campaign).groupBy { it.slot.start.toddMMMyyyy() }
+        return facility .groupBy { it.slot.start.toddMMMyyyy() }
             .map { (_, appointment) -> appointment.minBy { it.createdOn } }
     }
 

--- a/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepository.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepository.kt
@@ -108,11 +108,11 @@ interface GenericRepository {
         uuid: String = UUIDBuilder.generateUUID()
     ): Long
 
-    suspend fun updateAppointmentFhirIds()
+    suspend fun updateAppointmentFhirIds(genericTypeEnum: GenericTypeEnum)
     suspend fun updateAppointmentFhirIdInPatch()
 
-    suspend fun updateCVDFhirIds()
-    suspend fun updateVitalFhirId()
+    suspend fun updateCVDFhirIds(genericTypeEnum: GenericTypeEnum)
+    suspend fun updateVitalFhirId(genericTypeEnum: GenericTypeEnum)
     suspend fun updateDiagnosisFhirId()
     suspend fun updatePriorDxFhirId()
     suspend fun updateHistoryMedicationFhirId()

--- a/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepositoryDatabaseTransactions.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepositoryDatabaseTransactions.kt
@@ -835,7 +835,7 @@ open class GenericRepositoryDatabaseTransactions(
     }
 
     private suspend fun getPatientFhirIdById(patientId: String): String? {
-        return patientDao.getPatientDataById(patientId)[0].patientEntity.fhirId
+        return patientDao.getPatientDataById(patientId).firstOrNull()?.patientEntity?.fhirId
     }
 
     private suspend fun getScheduleFhirIdById(scheduleId: String): String? {

--- a/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepositoryImpl.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepositoryImpl.kt
@@ -94,12 +94,8 @@ class GenericRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun updateAppointmentFhirIds() {
-        genericDao.getNotSyncedData(GenericTypeEnum.APPOINTMENT)
-            .forEach { appointmentGenericEntity ->
-                updateAppointmentFhirIdInGenericEntity(appointmentGenericEntity)
-            }
-        genericDao.getNotSyncedData(GenericTypeEnum.CAMPAIGN_APPOINTMENT)
+    override suspend fun updateAppointmentFhirIds(genericTypeEnum: GenericTypeEnum) {
+        genericDao.getNotSyncedData(genericTypeEnum)
             .forEach { appointmentGenericEntity ->
                 updateAppointmentFhirIdInGenericEntity(appointmentGenericEntity)
             }
@@ -110,28 +106,16 @@ class GenericRepositoryImpl @Inject constructor(
             .forEach { appointmentGenericEntity ->
                 updateAppointmentFhirIdInGenericEntityPatch(appointmentGenericEntity)
             }
-        genericDao.getNotSyncedData(GenericTypeEnum.CAMPAIGN_APPOINTMENT, SyncType.PATCH)
-            .forEach { appointmentGenericEntity ->
-                updateAppointmentFhirIdInGenericEntityPatch(appointmentGenericEntity)
-            }
     }
 
-    override suspend fun updateCVDFhirIds() {
-        genericDao.getNotSyncedData(GenericTypeEnum.CVD)
-            .forEach { cvdGenericEntity ->
-                updateCVDFhirIdInGenericEntity(cvdGenericEntity)
-            }
-        genericDao.getNotSyncedData(GenericTypeEnum.CAMPAIGN_CVD)
+    override suspend fun updateCVDFhirIds(genericTypeEnum: GenericTypeEnum) {
+        genericDao.getNotSyncedData(genericTypeEnum)
             .forEach { cvdGenericEntity ->
                 updateCVDFhirIdInGenericEntity(cvdGenericEntity)
             }
     }
-    override suspend fun updateVitalFhirId() {
+    override suspend fun updateVitalFhirId(genericTypeEnum: GenericTypeEnum) {
         genericDao.getNotSyncedData(GenericTypeEnum.VITAL)
-            .forEach { vitalGenericEntity ->
-                updateVitalFhirIdInGenericEntity(vitalGenericEntity)
-            }
-        genericDao.getNotSyncedData(GenericTypeEnum.CAMPAIGN_VITAL)
             .forEach { vitalGenericEntity ->
                 updateVitalFhirIdInGenericEntity(vitalGenericEntity)
             }

--- a/app/src/main/java/com/heartcare/agni/data/server/repository/sync/SyncRepositoryDatabaseTransactions.kt
+++ b/app/src/main/java/com/heartcare/agni/data/server/repository/sync/SyncRepositoryDatabaseTransactions.kt
@@ -357,7 +357,7 @@ open class SyncRepositoryDatabaseTransactions(
                         createResponse.id!!, createResponse.fhirId!!
                     )
                 }else{
-                    campaignAppointmentDao.updateAppointmentFhirId(
+                    appointmentDao.updateAppointmentFhirId(
                         createResponse.id!!, createResponse.fhirId!!
                     )
                 }

--- a/app/src/main/java/com/heartcare/agni/data/server/repository/sync/SyncRepositoryImpl.kt
+++ b/app/src/main/java/com/heartcare/agni/data/server/repository/sync/SyncRepositoryImpl.kt
@@ -1452,7 +1452,7 @@ class SyncRepositoryImpl @Inject constructor(
                 if (listOfGenericEntity.isEmpty()) ApiEmptyResponse()
                 else ApiResponseConverter.convert(
                     cvdApiService.createCVD(EndPoints.CAMPAIGN_CVD, listOfGenericEntity.map {
-                        it.payload.fromJson<LinkedTreeMap<*, *>>().mapToObject(CVDResponse::class.java)!!
+                        it.payload.fromJson<LinkedTreeMap<*, *>>().mapToObject(CVDResponse::class.java)!!.copy(campaignId = null)
                     })
                 ).run {
                     when (this) {
@@ -1536,7 +1536,7 @@ class SyncRepositoryImpl @Inject constructor(
                 else ApiResponseConverter.convert(
                     vitalApiService.createData(CAMPAIGN_VITAL, listOfGenericEntity.map {
                         it.payload.fromJson<LinkedTreeMap<*, *>>()
-                            .mapToObject(VitalResponse::class.java)!!
+                            .mapToObject(VitalResponse::class.java)!!.copy(campaignId = null)
                     })
                 ).run {
                     when (this) {

--- a/app/src/main/java/com/heartcare/agni/service/sync/SyncService.kt
+++ b/app/src/main/java/com/heartcare/agni/service/sync/SyncService.kt
@@ -1,6 +1,7 @@
 package com.heartcare.agni.service.sync
 
 import android.content.Context
+import com.heartcare.agni.data.local.enums.GenericTypeEnum
 import com.heartcare.agni.data.local.repository.generic.GenericRepository
 import com.heartcare.agni.data.local.repository.preference.PreferenceRepository
 import com.heartcare.agni.data.server.repository.sync.SyncRepository
@@ -79,10 +80,10 @@ class SyncService(
                 },
                 async {
                     uploadSchedule(logout)
+                },
+                async {
+                    uploadCampaignSchedule(logout)
                 }
-//                , async {
-//                    uploadCampaignSchedule(logout)
-//                }
             ).all { responseMapper ->
                 responseMapper is ApiEmptyResponse
             }.apply {
@@ -105,6 +106,8 @@ class SyncService(
             awaitAll(
                 async {
                     updateFhirIdsInAppointment(logout)
+                },async {
+                    updateFhirIdsInCampaignAppointment(logout)
                 },
                 appointmentPatchJob
             ).all { responseMapper ->
@@ -114,9 +117,9 @@ class SyncService(
                     scheduleDownloadJob = async {
                         downloadSchedule(logout)
                     }
-//                    campaignScheduleDownloadJob = async {
-//                        downloadCampaignSchedule(logout)
-//                    }
+                    campaignScheduleDownloadJob = async {
+                        downloadCampaignSchedule(logout)
+                    }
                     downloadAppointmentJob(logout)
                 }
             }
@@ -135,10 +138,11 @@ class SyncService(
             awaitAll(
                 patientDownloadJob,
                 scheduleDownloadJob,
-//                campaignScheduleDownloadJob
+                campaignScheduleDownloadJob
             ).all { responseMapper -> responseMapper is ApiEndResponse }.apply {
                 if (this) {
                     downloadAppointment(logout)
+                    downloadCampaignAppointment(logout)
                 }
             }
         }
@@ -187,9 +191,8 @@ class SyncService(
             syncRepository.sendAppointmentPostData(),
             logout
         )
-        val campaignResponse = uploadCampaignAppointment(logout)
         coroutineScope {
-            if (response is ApiEmptyResponse || campaignResponse is ApiEmptyResponse) {
+            if (response is ApiEmptyResponse) {
                 // Run all update jobs concurrently
                 val jobs = listOf(
                     async { updateFhirIdInCVD(logout) },
@@ -214,6 +217,24 @@ class SyncService(
         return response
     }
 
+    /** Upload Campaign Appointment */
+    private suspend fun uploadCampaignAppointment(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
+         val response= checkAuthenticationStatus(syncRepository.sendCampaignAppointmentPostData(), logout)
+        coroutineScope {
+            if (response is ApiEmptyResponse) {
+                // Run all update jobs concurrently
+                val jobs = listOf(
+                    async { updateFhirIdInCampaignCVD(logout) },
+                    async { updateFhirIdInCampaignVital(logout) }
+                )
+
+                // Wait for all of them to complete
+                jobs.awaitAll()
+            }
+        }
+        return response
+    }
+
     /** Upload Form Prescription*/
     private suspend fun uploadFormPrescriptionData(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
         return checkAuthenticationStatus(syncRepository.sendFormPrescriptionPostData(), logout)
@@ -228,6 +249,10 @@ class SyncService(
     private suspend fun uploadCVD(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
         return checkAuthenticationStatus(syncRepository.sendCVDPostData(), logout)
     }
+    /** Upload Campaign CVD */
+    private suspend fun uploadCampaignCVD(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
+        return checkAuthenticationStatus(syncRepository.sendCampaignCVDPostData(), logout)
+    }
 
     /** Upload Diagnosis */
     private suspend fun uploadDiagnosis(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
@@ -237,17 +262,6 @@ class SyncService(
     /** Upload Vital */
     private suspend fun uploadVital(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
         return checkAuthenticationStatus(syncRepository.sendVitalPostData(), logout)
-    }
-
-
-    /** Upload Campaign Appointment */
-    private suspend fun uploadCampaignAppointment(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
-        return checkAuthenticationStatus(syncRepository.sendCampaignAppointmentPostData(), logout)
-    }
-
-    /** Upload Campaign CVD */
-    private suspend fun uploadCampaignCVD(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
-        return checkAuthenticationStatus(syncRepository.sendCampaignCVDPostData(), logout)
     }
 
     /** Upload Campaign Vital */
@@ -376,16 +390,12 @@ class SyncService(
                 syncRepository.getAndInsertAppointment(0),
                 logout
             )
-//            val campaignResponse = downloadCampaignAppointment(logout)
 
-
-//            if (response is ApiEmptyResponse || response is ApiEndResponse  || campaignResponse is ApiEmptyResponse || campaignResponse is ApiEndResponse) {
             if (response is ApiEmptyResponse || response is ApiEndResponse) {
                 val jobs = listOf(
                     async { downloadPatientLastUpdated(logout) },
                     async { downloadCVD(logout) },
                     async { downloadVitals(logout) },
-                    async { downloadCampaignVitals(logout) },
                     async { downloadPriorDx(logout) },
                     async { downloadHistoryMedication(logout) },
                     async { downloadFamilyHistory(logout) },
@@ -407,8 +417,24 @@ class SyncService(
                         examinationPatchJob.await()
                         downloadExamination(logout)
                     },
-                    async { downloadReferral(logout) },
-//                    async { downloadCampaignCVD(logout) }
+                    async { downloadReferral(logout) }
+                )
+                jobs.awaitAll()
+            }
+
+            response
+        }
+
+    /** Download Campaign Appointment */
+    private suspend fun downloadCampaignAppointment(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? =
+        coroutineScope {
+            val response = checkAuthenticationStatus(syncRepository.getAndInsertCampaignAppointment(0), logout)
+
+            if (response is ApiEmptyResponse || response is ApiEndResponse) {
+                val jobs = listOf(
+                    async { downloadPatientLastUpdated(logout) },
+                    async { downloadCampaignCVD(logout) },
+                    async { downloadCampaignVitals(logout) }
                 )
                 jobs.awaitAll()
             }
@@ -482,6 +508,11 @@ class SyncService(
         return checkAuthenticationStatus(syncRepository.getAndInsertCVD(0), logout)
     }
 
+    /** Download Campaign CVD */
+    private suspend fun downloadCampaignCVD(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
+        return checkAuthenticationStatus(syncRepository.getAndInsertCampaignCVD(0), logout)
+    }
+
     /** Download Diagnosis*/
     private suspend fun downloadDiagnosis(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
         return checkAuthenticationStatus(
@@ -503,15 +534,6 @@ class SyncService(
         return checkAuthenticationStatus(syncRepository.getAndInsertCampaignSchedule(0), logout)
     }
 
-    /** Download Campaign Appointment */
-    private suspend fun downloadCampaignAppointment(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
-        return checkAuthenticationStatus(syncRepository.getAndInsertCampaignAppointment(0), logout)
-    }
-
-    /** Download Campaign CVD */
-    private suspend fun downloadCampaignCVD(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
-        return checkAuthenticationStatus(syncRepository.getAndInsertCampaignCVD(0), logout)
-    }
 
     /** Download Levels Data */
     private suspend fun downloadLevelsRecord(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
@@ -601,9 +623,14 @@ class SyncService(
 
     /** Update Schedule and Patient FHIR ID in Appointment */
     private suspend fun updateFhirIdsInAppointment(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
-        genericRepository.updateAppointmentFhirIds()
+        genericRepository.updateAppointmentFhirIds(GenericTypeEnum.APPOINTMENT)
         /** Upload Appointment */
         return uploadAppointment(logout)
+    }
+    private suspend fun updateFhirIdsInCampaignAppointment(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
+        genericRepository.updateAppointmentFhirIds(GenericTypeEnum.CAMPAIGN_APPOINTMENT)
+        /** Upload Campaign Appointment */
+        return uploadCampaignAppointment(logout)
     }
 
     /** Update Schedule FHIR ID in Appointment Patch */
@@ -622,17 +649,26 @@ class SyncService(
 
     /** Update Appointment FHIR ID in CVD */
     private suspend fun updateFhirIdInCVD(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
-        genericRepository.updateCVDFhirIds()
+        genericRepository.updateCVDFhirIds(GenericTypeEnum.CVD)
         val cvdResponse = uploadCVD(logout)
-//        uploadCampaignCVD(logout)
+        return cvdResponse
+    }
+    /** Update Appointment FHIR ID in CVD */
+    private suspend fun updateFhirIdInCampaignCVD(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
+        genericRepository.updateCVDFhirIds(GenericTypeEnum.CAMPAIGN_CVD)
+        val cvdResponse = uploadCampaignCVD(logout)
         return cvdResponse
     }
 
     /** Update Appointment FHIR ID in Vitals */
     private suspend fun updateFhirIdInVital(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
-        genericRepository.updateVitalFhirId()
+        genericRepository.updateVitalFhirId(GenericTypeEnum.VITAL)
         val vitalResponse = uploadVital(logout)
-//        uploadCampaignVital(logout)
+        return vitalResponse
+    }
+    private suspend fun updateFhirIdInCampaignVital(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
+        genericRepository.updateVitalFhirId(GenericTypeEnum.CAMPAIGN_VITAL)
+       val vitalResponse= uploadCampaignVital(logout)
         return vitalResponse
     }
 

--- a/app/src/main/java/com/heartcare/agni/ui/patientlandingscreen/PatientLandingScreenViewModel.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/patientlandingscreen/PatientLandingScreenViewModel.kt
@@ -19,6 +19,7 @@ import com.heartcare.agni.di.dispatcher.IoDispatcher
 import com.heartcare.agni.service.workmanager.utils.Sync
 import com.heartcare.agni.service.workmanager.workers.trigger.TriggerWorkerPeriodicImpl
 import com.heartcare.agni.utils.common.Queries.getInProgressCompletedAppointmentIds
+import com.heartcare.agni.utils.common.Queries.getScreenSiteAppointmentIds
 import com.heartcare.agni.utils.converters.responseconverter.TimeConverter.toEndOfDay
 import com.heartcare.agni.utils.converters.responseconverter.TimeConverter.toTodayStartDate
 import com.heartcare.agni.utils.network.CheckNetwork
@@ -99,9 +100,9 @@ class PatientLandingScreenViewModel @Inject constructor(
 
     internal fun getLastCVDRisk(patientId: String) {
         viewModelScope.launch(ioDispatcher) {
-            val appointmentIds =
-                getInProgressCompletedAppointmentIds(patientId, appointmentRepository)
-            cvdRisk = (cvdAssessmentRepository.getCVDRecordByAppointmentIds(*appointmentIds.toTypedArray()).firstOrNull()?.risk ?: "").toString()
+            val appointmentIds = getInProgressCompletedAppointmentIds(patientId, appointmentRepository)
+            val campaignAppointmentIds = getScreenSiteAppointmentIds(patientId, appointmentRepository)
+            cvdRisk = (cvdAssessmentRepository.getCVDRecordByAppointmentIds(*(campaignAppointmentIds+appointmentIds).toTypedArray()).firstOrNull()?.risk ?: "").toString()
         }
     }
 }


### PR DESCRIPTION


## Guidelines
- It is mandatory to assign a reviewer to PR
- A Pull Request must always refer to single or related usecase. Non related usecases must not be a part of same Pull request
- If a Pull Request has mix of type of changes then the description section must point to relevent information for each type `Note : We must avoid merging multiple changes in a single PR`
  - Bug Fix : Point to all issue id's of the bugs fixed. One commit mapped to one bug id. Do not fix multiple bugs in a single commit
  - New Feature: Must point to a usecase or relevent documentation bug
  - Enhancement: Must point to a usecase or relevent documentation bug
  - Refactoring: The context of why the refactoring has been done. 

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
1. Update sync flow for CVD and Vitals to sync data from the server
2. Removed the campaign appointment logic  for sche

closes https://github.com/LatticeInnovations/LatticeOnFhirMain/issues/2044
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
For UI related change
Mobile screen config  5.0''; 1080 x 1920; 420dpi
Tablet screen config 10.1''; 800 x 1280; mdpi

| ScreenType|  GIF/Screenshot  |
|---|---|
| Mobile-potrait  |  <img src="https://user-images.githubusercontent.com/5468111/82522760-07db8900-9b48-11ea-8b7b-43ca1a0a425a.gif" width="260"> |
| Mobile-landscape   |<img src="https://user-images.githubusercontent.com/5468111/82523184-0363a000-9b49-11ea-8a92-2231a585c13c.gif" width="600">   |
-->
