### PR TITLE
[FEAT] - Integrate PriorDx with screening sites

### DIFF
--- a/app/schemas/com.heartcare.agni.data.local.roomdb.FhirAppDatabase/3.json
+++ b/app/schemas/com.heartcare.agni.data.local.roomdb.FhirAppDatabase/3.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 3,
-    "identityHash": "07afbd8c49bf0e90950170e2dd59a9bc",
+    "identityHash": "0282f923a8de40e5fbeb06e87fa2ee9b",
     "entities": [
       {
         "tableName": "PatientEntity",
@@ -1702,7 +1702,7 @@
       },
       {
         "tableName": "PriorDxEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`priorDxUuid` TEXT NOT NULL, `priorDxFhirId` TEXT, `appointmentId` TEXT NOT NULL, `cancer` TEXT, `createdOn` INTEGER NOT NULL, `hasAids` INTEGER NOT NULL, `hasAsthma` INTEGER NOT NULL, `hasCancer` INTEGER NOT NULL, `hasChronicKidneyDiseases` INTEGER NOT NULL, `hasChronicObstructivePulmonaryDisease` INTEGER NOT NULL, `hasCovid` INTEGER NOT NULL, `hasDiabetes` INTEGER NOT NULL, `hasHeartDiseases` INTEGER NOT NULL, `hasHypercholesterolaemia` INTEGER NOT NULL, `hasHypertension` INTEGER NOT NULL, `hasOthers` INTEGER NOT NULL, `hasTransientIschaemicAttack` INTEGER NOT NULL, `hasTuberculosis` INTEGER NOT NULL, `others` TEXT, `patientId` TEXT NOT NULL, `practitionerId` TEXT NOT NULL, `practitionerName` TEXT NOT NULL, PRIMARY KEY(`priorDxUuid`), FOREIGN KEY(`patientId`) REFERENCES `PatientEntity`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`appointmentId`) REFERENCES `AppointmentEntity`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`priorDxUuid` TEXT NOT NULL, `priorDxFhirId` TEXT, `appointmentId` TEXT, `campaignAppointmentId` TEXT, `cancer` TEXT, `createdOn` INTEGER NOT NULL, `hasAids` INTEGER NOT NULL, `hasAsthma` INTEGER NOT NULL, `hasCancer` INTEGER NOT NULL, `hasChronicKidneyDiseases` INTEGER NOT NULL, `hasChronicObstructivePulmonaryDisease` INTEGER NOT NULL, `hasCovid` INTEGER NOT NULL, `hasDiabetes` INTEGER NOT NULL, `hasHeartDiseases` INTEGER NOT NULL, `hasHypercholesterolaemia` INTEGER NOT NULL, `hasHypertension` INTEGER NOT NULL, `hasOthers` INTEGER NOT NULL, `hasTransientIschaemicAttack` INTEGER NOT NULL, `hasTuberculosis` INTEGER NOT NULL, `others` TEXT, `patientId` TEXT NOT NULL, `practitionerId` TEXT, `practitionerName` TEXT, `campaignId` TEXT, PRIMARY KEY(`priorDxUuid`), FOREIGN KEY(`patientId`) REFERENCES `PatientEntity`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`appointmentId`) REFERENCES `AppointmentEntity`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`campaignAppointmentId`) REFERENCES `CampaignAppointmentEntity`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
         "fields": [
           {
             "fieldPath": "priorDxUuid",
@@ -1718,8 +1718,12 @@
           {
             "fieldPath": "appointmentId",
             "columnName": "appointmentId",
-            "affinity": "TEXT",
-            "notNull": true
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "campaignAppointmentId",
+            "columnName": "campaignAppointmentId",
+            "affinity": "TEXT"
           },
           {
             "fieldPath": "cancer",
@@ -1824,14 +1828,17 @@
           {
             "fieldPath": "practitionerId",
             "columnName": "practitionerId",
-            "affinity": "TEXT",
-            "notNull": true
+            "affinity": "TEXT"
           },
           {
             "fieldPath": "practitionerName",
             "columnName": "practitionerName",
-            "affinity": "TEXT",
-            "notNull": true
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "campaignId",
+            "columnName": "campaignId",
+            "affinity": "TEXT"
           }
         ],
         "primaryKey": {
@@ -1878,6 +1885,17 @@
             "onUpdate": "NO ACTION",
             "columns": [
               "appointmentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "CampaignAppointmentEntity",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "campaignAppointmentId"
             ],
             "referencedColumns": [
               "id"
@@ -3391,7 +3409,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '07afbd8c49bf0e90950170e2dd59a9bc')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0282f923a8de40e5fbeb06e87fa2ee9b')"
     ]
   }
 }

--- a/app/src/main/java/com/heartcare/agni/data/local/enums/GenericTypeEnum.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/enums/GenericTypeEnum.kt
@@ -23,5 +23,6 @@ enum class GenericTypeEnum(val number: Int, val value: String) {
     CAMPAIGN_APPOINTMENT(20, "Campaign_Appointment"),
     CAMPAIGN_SCHEDULE(21, "Campaign_Schedule"),
     CAMPAIGN_CVD(22, "Campaign_CVD_Record"),
-    CAMPAIGN_VITAL(23, "Campaign_Vital_Record");
+    CAMPAIGN_VITAL(23, "Campaign_Vital_Record"),
+    CAMPAIGN_PRIOR_DX(24, "Campaign_Prior_Dx_Record");
 }

--- a/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepository.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepository.kt
@@ -114,7 +114,7 @@ interface GenericRepository {
     suspend fun updateCVDFhirIds(genericTypeEnum: GenericTypeEnum)
     suspend fun updateVitalFhirId(genericTypeEnum: GenericTypeEnum)
     suspend fun updateDiagnosisFhirId()
-    suspend fun updatePriorDxFhirId()
+    suspend fun updatePriorDxFhirId(genericTypeEnum: GenericTypeEnum)
     suspend fun updateHistoryMedicationFhirId()
     suspend fun updateFamilyHistoryFhirId()
     suspend fun updateAllergyFhirId()

--- a/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepositoryDatabaseTransactions.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepositoryDatabaseTransactions.kt
@@ -298,6 +298,8 @@ open class GenericRepositoryDatabaseTransactions(
         priorDxResponse: PriorDxResponse,
         uuid: String
     ): Long {
+        val type = if (priorDxResponse.campaignId != null) GenericTypeEnum.CAMPAIGN_PRIOR_DX else GenericTypeEnum.PRIOR_DX
+
         return if (priorDxGenericEntity != null) {
             genericDao.insertGenericEntity(
                 priorDxGenericEntity.copy(payload = priorDxResponse.toJson())
@@ -308,7 +310,7 @@ open class GenericRepositoryDatabaseTransactions(
                     id = uuid,
                     patientId = priorDxResponse.priorDxUuid,
                     payload = priorDxResponse.toJson(),
-                    type = GenericTypeEnum.PRIOR_DX,
+                    type = type,
                     syncType = SyncType.POST
                 )
             )[0]

--- a/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepositoryImpl.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepositoryImpl.kt
@@ -127,8 +127,8 @@ class GenericRepositoryImpl @Inject constructor(
             }
     }
 
-    override suspend fun updatePriorDxFhirId() {
-        genericDao.getNotSyncedData(GenericTypeEnum.PRIOR_DX)
+    override suspend fun updatePriorDxFhirId(genericTypeEnum: GenericTypeEnum) {
+        genericDao.getNotSyncedData(genericTypeEnum)
             .forEach { priorDxGenericEntity ->
                 updatePriorDxFhirIdInGenericEntity(priorDxGenericEntity)
             }
@@ -229,9 +229,10 @@ class GenericRepositoryImpl @Inject constructor(
     }
 
     override suspend fun insertPriorDxRecord(priorDxResponse: PriorDxResponse, uuid: String): Long {
+        val type = if (priorDxResponse.campaignId != null) GenericTypeEnum.CAMPAIGN_PRIOR_DX else GenericTypeEnum.PRIOR_DX
         return genericDao.getGenericEntityById(
             patientId = priorDxResponse.priorDxUuid,
-            genericTypeEnum = GenericTypeEnum.PRIOR_DX,
+            genericTypeEnum = type,
             syncType = SyncType.POST
         ).let { priorDxGenericEntity ->
             insertPriorDxGenericEntity(priorDxGenericEntity, priorDxResponse, uuid)

--- a/app/src/main/java/com/heartcare/agni/data/local/repository/priordx/PriorDxRepository.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/repository/priordx/PriorDxRepository.kt
@@ -5,4 +5,5 @@ import com.heartcare.agni.data.server.model.priordx.PriorDxResponse
 interface PriorDxRepository {
     suspend fun insertPriorDx(vararg priorDxResponse: PriorDxResponse): List<Long>
     suspend fun getPriorDxRecordsByAppointmentIds(vararg appointmentIds: String): List<PriorDxResponse>
+    suspend fun getLatestPriorDxForCampaign(patientId: String, campaignId: String): PriorDxResponse?
 }

--- a/app/src/main/java/com/heartcare/agni/data/local/repository/priordx/PriorDxRepositoryImpl.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/repository/priordx/PriorDxRepositoryImpl.kt
@@ -16,4 +16,11 @@ class PriorDxRepositoryImpl @Inject constructor(
     override suspend fun getPriorDxRecordsByAppointmentIds(vararg appointmentIds: String): List<PriorDxResponse> {
         return priorDxDao.getPriorDxRecordsByAppointmentIds(*appointmentIds).map { it.toPriorDxResponse() }
     }
+
+    override suspend fun getLatestPriorDxForCampaign(
+        patientId: String,
+        campaignId: String
+    ): PriorDxResponse? {
+        return priorDxDao.getLatestPriorDxForCampaign(patientId, campaignId)?.toPriorDxResponse()
+    }
 }

--- a/app/src/main/java/com/heartcare/agni/data/local/roomdb/dao/PriorDxDao.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/roomdb/dao/PriorDxDao.kt
@@ -11,8 +11,11 @@ interface PriorDxDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertPriorDxRecord(vararg priorDxEntity: PriorDxEntity): List<Long>
 
-    @Query("SELECT * FROM PriorDxEntity WHERE appointmentId IN (:appointmentIds) ORDER BY createdOn DESC")
+    @Query("SELECT * FROM PriorDxEntity WHERE appointmentId IN (:appointmentIds) OR campaignAppointmentId IN (:appointmentIds) ORDER BY createdOn DESC")
     fun getPriorDxRecordsByAppointmentIds(vararg appointmentIds: String): List<PriorDxEntity>
+
+    @Query("SELECT * FROM PriorDxEntity WHERE patientId = :patientId AND campaignId = :campaignId ORDER BY createdOn DESC LIMIT 1")
+    suspend fun getLatestPriorDxForCampaign(patientId: String, campaignId: String): PriorDxEntity?
 
     @Query("UPDATE PriorDxEntity SET priorDxFhirId = :fhirId WHERE priorDxUuid = :id")
     suspend fun updateFhirId(id: String, fhirId: String): Int

--- a/app/src/main/java/com/heartcare/agni/data/local/roomdb/entities/priordx/PriorDxEntity.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/roomdb/entities/priordx/PriorDxEntity.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import com.heartcare.agni.data.local.roomdb.entities.appointment.AppointmentEntity
+import com.heartcare.agni.data.local.roomdb.entities.campaign.CampaignAppointmentEntity
 import com.heartcare.agni.data.local.roomdb.entities.patient.PatientEntity
 import java.util.Date
 
@@ -22,13 +23,19 @@ import java.util.Date
             entity = AppointmentEntity::class,
             parentColumns = ["id"],
             childColumns = ["appointmentId"]
+        ),
+        ForeignKey(
+            entity = CampaignAppointmentEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["campaignAppointmentId"]
         )
     ]
 )
 data class PriorDxEntity (
     val priorDxUuid: String,
     val priorDxFhirId: String?,
-    val appointmentId: String,
+    val appointmentId: String?,
+    val campaignAppointmentId: String?,
     val cancer: String?,
     val createdOn: Date,
     val hasAids: Boolean,
@@ -46,6 +53,7 @@ data class PriorDxEntity (
     val hasTuberculosis: Boolean,
     val others: String?,
     val patientId: String,
-    val practitionerId: String,
-    val practitionerName: String
+    val practitionerId: String?,
+    val practitionerName: String?,
+    val campaignId: String?
 )

--- a/app/src/main/java/com/heartcare/agni/data/server/api/HistoryAndTestsApiService.kt
+++ b/app/src/main/java/com/heartcare/agni/data/server/api/HistoryAndTestsApiService.kt
@@ -5,6 +5,7 @@ import com.heartcare.agni.data.server.constants.EndPoints.ALLERGY
 import com.heartcare.agni.data.server.constants.EndPoints.FAMILY_HISTORY
 import com.heartcare.agni.data.server.constants.EndPoints.HISTORY_MEDICATION
 import com.heartcare.agni.data.server.constants.EndPoints.PRIOR_DX
+import com.heartcare.agni.data.server.constants.EndPoints.CAMPAIGN_PRIOR_DX
 import com.heartcare.agni.data.server.constants.EndPoints.RISK_FACTOR
 import com.heartcare.agni.data.server.constants.EndPoints.TOBACCO_CESSATION
 import com.heartcare.agni.data.server.model.allergy.AllergyResponse
@@ -26,6 +27,12 @@ interface HistoryAndTestsApiService {
 
     @GET(PRIOR_DX)
     suspend fun getPriorDx(@QueryMap(encoded = true) map: Map<String, String>?): Response<BaseResponse<List<PriorDxResponse>>>
+
+    @POST(CAMPAIGN_PRIOR_DX)
+    suspend fun postCampaignPriorDx(@Body priorDxResponse: List<PriorDxResponse>): Response<BaseResponse<List<CreateResponse>>>
+
+    @GET(CAMPAIGN_PRIOR_DX)
+    suspend fun getCampaignPriorDx(@QueryMap(encoded = true) map: Map<String, String>?): Response<BaseResponse<List<PriorDxResponse>>>
 
     @POST(HISTORY_MEDICATION)
     suspend fun postHistoryMedication(@Body historyMedicationResponse: List<HistoryMedicationResponse>): Response<BaseResponse<List<CreateResponse>>>

--- a/app/src/main/java/com/heartcare/agni/data/server/api/ScheduleAndAppointmentApiService.kt
+++ b/app/src/main/java/com/heartcare/agni/data/server/api/ScheduleAndAppointmentApiService.kt
@@ -40,9 +40,6 @@ interface ScheduleAndAppointmentApiService {
         @Body appointmentResponse: List<Any>
     ): Response<BaseResponse<List<CreateResponse>>>
 
-    @PATCH("{endPoint}")
-    suspend fun patchListOfChanges(
-        @Path("endPoint", encoded = true) endPoint: String,
-        @Body patchLogs: List<Map<String, Any>>
-    ): Response<BaseResponse<List<CreateResponse>>>
+    @PATCH("Appointment")
+    suspend fun patchListOfChanges(@Body patchLogs: List<Map<String, Any>>): Response<BaseResponse<List<CreateResponse>>>
 }

--- a/app/src/main/java/com/heartcare/agni/data/server/constants/EndPoints.kt
+++ b/app/src/main/java/com/heartcare/agni/data/server/constants/EndPoints.kt
@@ -22,5 +22,5 @@ object EndPoints {
     const val CAMPAIGN_APPOINTMENT = "campaign/Appointment"
     const val CAMPAIGN_CVD = "campaign/CVD"
     const val CAMPAIGN_VITAL = "campaign/Vital"
-    const val PATCH_LOGS = "Schedule/AppLog"
+    const val CAMPAIGN_PRIOR_DX = "campaign/priorDx"
 }

--- a/app/src/main/java/com/heartcare/agni/data/server/model/priordx/PriorDxResponse.kt
+++ b/app/src/main/java/com/heartcare/agni/data/server/model/priordx/PriorDxResponse.kt
@@ -29,5 +29,7 @@ data class PriorDxResponse(
     val patientId: String,
     val practitionerId: String?,
     val practitionerName: String?,
-    val appUpdatedDate: Date?
+    val appUpdatedDate: Date?,
+    val campaignId: String?,
+    val screeningSiteName: String? =null
 )

--- a/app/src/main/java/com/heartcare/agni/data/server/repository/sync/SyncRepository.kt
+++ b/app/src/main/java/com/heartcare/agni/data/server/repository/sync/SyncRepository.kt
@@ -52,6 +52,7 @@ interface SyncRepository {
     suspend fun getAndInsertLevelsData(offset: Int): ResponseMapper<List<LevelResponse>>
     suspend fun getAndInsertHealthFacilityData(offset: Int): ResponseMapper<List<HealthFacilityResponse>>
     suspend fun getAndInsertPriorDxData(offset: Int): ResponseMapper<List<PriorDxResponse>>
+    suspend fun getAndInsertCampaignPriorDxData(offset: Int): ResponseMapper<List<PriorDxResponse>>
     suspend fun getAndInsertHistoryMedicationData(offset: Int): ResponseMapper<List<HistoryMedicationResponse>>
     suspend fun getAndInsertFamilyHistoryData(offset: Int): ResponseMapper<List<FamilyHistoryResponse>>
     suspend fun getAndInsertAllergyData(offset: Int): ResponseMapper<List<AllergyResponse>>
@@ -75,6 +76,7 @@ interface SyncRepository {
     suspend fun sendVitalPostData(): ResponseMapper<List<CreateResponse>>
     suspend fun sendDiagnosisPostData(): ResponseMapper<List<CreateResponse>>
     suspend fun sendPriorDxPostData(): ResponseMapper<List<CreateResponse>>
+    suspend fun sendCampaignPriorDxPostData(): ResponseMapper<List<CreateResponse>>
     suspend fun sendHistoryMedicationPostData(): ResponseMapper<List<CreateResponse>>
     suspend fun sendFamilyHistoryPostData(): ResponseMapper<List<CreateResponse>>
     suspend fun sendAllergyPostData(): ResponseMapper<List<CreateResponse>>

--- a/app/src/main/java/com/heartcare/agni/data/server/repository/sync/SyncRepositoryDatabaseTransactions.kt
+++ b/app/src/main/java/com/heartcare/agni/data/server/repository/sync/SyncRepositoryDatabaseTransactions.kt
@@ -661,7 +661,7 @@ open class SyncRepositoryDatabaseTransactions(
 
     protected suspend fun insertPriorDx(body: List<PriorDxResponse>) {
         priorDxDao.insertPriorDxRecord(
-            *body.map { it.toPriorDxEntity(patientDao, appointmentDao) }.toTypedArray()
+            *body.map { it.toPriorDxEntity(patientDao, appointmentDao, campaignAppointmentDao) }.toTypedArray()
         )
     }
 

--- a/app/src/main/java/com/heartcare/agni/data/server/repository/sync/SyncRepositoryImpl.kt
+++ b/app/src/main/java/com/heartcare/agni/data/server/repository/sync/SyncRepositoryImpl.kt
@@ -1624,7 +1624,50 @@ class SyncRepositoryImpl @Inject constructor(
                         historyAndTestsApiService.postPriorDx(
                             listOfGenericEntity.map {
                                 it.payload.fromJson<LinkedTreeMap<*, *>>()
-                                    .mapToObject(PriorDxResponse::class.java)!!
+                                    .mapToObject(PriorDxResponse::class.java)!!.copy(campaignId = null)
+                            }
+                        )
+                    ).apply {
+                        if (this is ApiEndResponse) {
+                            insertPriorDxFhirIds(body, listOfGenericEntity)
+                                .apply {
+                                    if (this > 0) sendPriorDxPostData()
+                                }
+                        }
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Timber.e(e, e.localizedMessage)
+            crashlyticsLogger.logException(
+                e,
+                "sendPriorDxPostData function failed.",
+                mapOf(
+                    Pair(
+                        USER_ID,
+                        preferenceRepository.getUserDetails()?.userId ?: ERROR_FETCHING_USER_DETAILS
+                    )
+                )
+            )
+            ApiErrorResponse(
+                statusCode = 0,
+                errorMessage = e.localizedMessage ?: SOMETHING_WENT_WRONG
+            )
+        }
+    }
+    override suspend fun sendCampaignPriorDxPostData(): ResponseMapper<List<CreateResponse>> {
+        return try {
+            genericDao.getSameTypeGenericEntityPayload(
+                genericTypeEnum = GenericTypeEnum.CAMPAIGN_PRIOR_DX,
+                syncType = SyncType.POST
+            ).let { listOfGenericEntity ->
+                if (listOfGenericEntity.isEmpty()) ApiEmptyResponse()
+                else {
+                    ApiResponseConverter.convert(
+                        historyAndTestsApiService.postCampaignPriorDx(
+                            listOfGenericEntity.map {
+                                it.payload.fromJson<LinkedTreeMap<*, *>>()
+                                    .mapToObject(PriorDxResponse::class.java)!!.copy(campaignId = null)
                             }
                         )
                     ).apply {
@@ -2062,8 +2105,7 @@ class SyncRepositoryImpl @Inject constructor(
                 else {
                     ApiResponseConverter.convert(
                         scheduleAndAppointmentApiService.patchListOfChanges(
-                            EndPoints.PATCH_LOGS,
-                            listOfGenericEntity.map { it.payload.fromJson<Map<String, Any>>() })
+                            listOfGenericEntity.map { it.payload.fromJson() })
                     ).run {
                         when (this) {
                             is ApiEndResponse -> {
@@ -2372,6 +2414,48 @@ class SyncRepositoryImpl @Inject constructor(
                         this
                     }
 
+                    else -> this
+                }
+            }
+        } catch (e: Exception) {
+            Timber.e(e, e.localizedMessage)
+            crashlyticsLogger.logException(
+                e,
+                "getAndInsertPriorDxData function failed.",
+                mapOf(
+                    Pair(
+                        USER_ID,
+                        preferenceRepository.getUserDetails()?.userId ?: ERROR_FETCHING_USER_DETAILS
+                    )
+                )
+            )
+            ApiErrorResponse(
+                statusCode = 0,
+                errorMessage = e.localizedMessage ?: SOMETHING_WENT_WRONG
+            )
+        }
+    }
+
+
+    override suspend fun getAndInsertCampaignPriorDxData(offset: Int): ResponseMapper<List<PriorDxResponse>> {
+        val map = mutableMapOf<String, String>()
+        map[COUNT] = COUNT_VALUE.toString()
+        map[OFFSET] = offset.toString()
+        map[SORT] = "-$ID"
+
+        return try {
+            ApiResponseConverter.convert(
+                historyAndTestsApiService.getCampaignPriorDx(map), true
+            ).run {
+                when (this) {
+                    is ApiContinueResponse -> {
+                        insertPriorDx(body)
+                        getAndInsertCampaignPriorDxData(offset + COUNT_VALUE)
+                    }
+                    is ApiEndResponse -> {
+                        insertPriorDx(body)
+                        this
+                    }
                     else -> this
                 }
             }

--- a/app/src/main/java/com/heartcare/agni/service/sync/SyncService.kt
+++ b/app/src/main/java/com/heartcare/agni/service/sync/SyncService.kt
@@ -225,7 +225,8 @@ class SyncService(
                 // Run all update jobs concurrently
                 val jobs = listOf(
                     async { updateFhirIdInCampaignCVD(logout) },
-                    async { updateFhirIdInCampaignVital(logout) }
+                    async { updateFhirIdInCampaignVital(logout) },
+                    async { updateFhirIdInCampaignPriorDx(logout) }
                 )
 
                 // Wait for all of them to complete
@@ -272,6 +273,11 @@ class SyncService(
     /** Upload Prior Dx */
     private suspend fun uploadPriorDx(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
         return checkAuthenticationStatus(syncRepository.sendPriorDxPostData(), logout)
+    }
+
+    /** Upload Campaign Prior Dx */
+    private suspend fun uploadCampaignPriorDx(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
+        return checkAuthenticationStatus(syncRepository.sendCampaignPriorDxPostData(), logout)
     }
 
     /** Upload History Medication */
@@ -434,7 +440,8 @@ class SyncService(
                 val jobs = listOf(
                     async { downloadPatientLastUpdated(logout) },
                     async { downloadCampaignCVD(logout) },
-                    async { downloadCampaignVitals(logout) }
+                    async { downloadCampaignVitals(logout) },
+                    async { downloadCampaignPriorDx(logout) }
                 )
                 jobs.awaitAll()
             }
@@ -527,6 +534,11 @@ class SyncService(
     }
     private suspend fun downloadCampaignVitals(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
         return checkAuthenticationStatus(syncRepository.getAndInsertCampaignVitalData(0), logout)
+    }
+
+    /** Download Campaign Prior Dx */
+    private suspend fun downloadCampaignPriorDx(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
+        return checkAuthenticationStatus(syncRepository.getAndInsertCampaignPriorDxData(0), logout)
     }
 
     /** Download Campaign Schedule */
@@ -672,6 +684,12 @@ class SyncService(
         return vitalResponse
     }
 
+    /** Update Appointment FHIR ID in Campaign Prior Dx */
+    private suspend fun updateFhirIdInCampaignPriorDx(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
+        genericRepository.updatePriorDxFhirId(GenericTypeEnum.CAMPAIGN_PRIOR_DX)
+        return uploadCampaignPriorDx(logout)
+    }
+
     /** Update Appointment FHIR ID in Diagnosis */
     private suspend fun updateFhirIdInDiagnosis(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
         genericRepository.updateDiagnosisFhirId()
@@ -680,7 +698,7 @@ class SyncService(
 
     /** Update FHIR ID in Prior Dx */
     private suspend fun updateFhirIdInPriorDx(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
-        genericRepository.updatePriorDxFhirId()
+        genericRepository.updatePriorDxFhirId(GenericTypeEnum.PRIOR_DX)
         return uploadPriorDx(logout)
     }
 

--- a/app/src/main/java/com/heartcare/agni/ui/common/ExpandableCard.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/common/ExpandableCard.kt
@@ -38,6 +38,7 @@ import java.util.Date
 fun ExpandableCard(
     createdOn: Date,
     practitionerName: String,
+    screenSiteName: String? = null,
     listOfItems: List<String>,
     isBulleted: Boolean,
     extraInfoComposable: (@Composable () -> Unit)? = null,
@@ -59,6 +60,14 @@ fun ExpandableCard(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+            Spacer(modifier = Modifier.padding(4.dp))
+            screenSiteName?.let {
+                Text(
+                    text = screenSiteName,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
 
             AnimatedVisibility(visible = expanded) {
                 ExpandedContent(

--- a/app/src/main/java/com/heartcare/agni/ui/cvd/CVDRiskAssessmentScreen.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/cvd/CVDRiskAssessmentScreen.kt
@@ -49,7 +49,6 @@ import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -488,7 +487,17 @@ private fun handleSaveButtonClick(
 
                             viewModel.isAppointmentCompleted -> viewModel.showAppointmentCompletedDialog = true
 
-                            else -> viewModel.showAddToQueueDialog = true
+                            else -> if (viewModel.selectedCampaignId!=null){
+                                viewModel.addPatientToQueue(
+                                    viewModel.patient!!,
+                                    addedToQueue = {
+                                        viewModel.showAddToQueueDialog = false
+                                        saveCVD(viewModel,onNavigate)
+                                    }
+                                )
+                            }else {
+                                viewModel.showAddToQueueDialog = true
+                            }
                         }
                     }
                 )

--- a/app/src/main/java/com/heartcare/agni/ui/cvd/CVDRiskAssessmentViewModel.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/cvd/CVDRiskAssessmentViewModel.kt
@@ -169,7 +169,7 @@ class CVDRiskAssessmentViewModel @Inject constructor(
         callback: () -> Unit
     ) {
         viewModelScope.launch(ioDispatcher) {
-            val patientId = patient?.id ?: return@launch
+            val patientId = patient!!.id
             val campaignId = selectedCampaignId
 
             val info = if (campaignId != null) {
@@ -388,10 +388,10 @@ class CVDRiskAssessmentViewModel @Inject constructor(
                 cvdResponse.copy(
                     appointmentId = appointmentResponseLocal!!.uuid,
                     patientId = patient!!.id,
-                    practitionerName = if (selectedCampaignId==null)getFullName(
+                    practitionerName = getFullName(
                         preferenceRepository.getUserDetails()!!.firstName,
                         preferenceRepository.getUserDetails()!!.lastName
-                    )else null
+                    )
                 )
             )
             genericRepository.insertCVDRecord(cvdResponse)

--- a/app/src/main/java/com/heartcare/agni/ui/historyandtests/HistoryTakingAndTestsScreen.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/historyandtests/HistoryTakingAndTestsScreen.kt
@@ -40,7 +40,6 @@ import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -74,13 +73,13 @@ import com.heartcare.agni.ui.patientlandingscreen.AllSlotsBookedDialog
 import com.heartcare.agni.ui.theme.Black
 import com.heartcare.agni.ui.theme.White
 import com.heartcare.agni.utils.constants.NavControllerConstants.ALLERGIES_SAVED
+import com.heartcare.agni.utils.constants.NavControllerConstants.CAMPAIGN_ID
 import com.heartcare.agni.utils.constants.NavControllerConstants.FAMILY_HISTORY_SAVED
 import com.heartcare.agni.utils.constants.NavControllerConstants.MEDICATION_SAVED
 import com.heartcare.agni.utils.constants.NavControllerConstants.PATIENT
 import com.heartcare.agni.utils.constants.NavControllerConstants.PRIOR_DX_SAVED
 import com.heartcare.agni.utils.constants.NavControllerConstants.RISK_FACTORS_SAVED
 import com.heartcare.agni.utils.constants.NavControllerConstants.TOBACCO_CESSATION_SAVED
-import com.heartcare.agni.utils.constants.ScreenSiteConstants.SITE_LIST
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -99,16 +98,13 @@ fun HistoryTakingAndTestsScreen(
         initialPageOffsetFraction = 0f
     ) { tabs.size }
 
-    var currentStep by remember { mutableIntStateOf(0) }
     var selectedSite by remember { mutableStateOf<String?>(null) }
-    var selectedType by remember { mutableStateOf<RecordType?>(null) }
-
     BackHandler {
-        if (currentStep > 0) {
-            if (currentStep == 2) {
-                currentStep = 1
-            } else if (currentStep == 1) {
-                currentStep = 0
+        if (viewModel.currentStep > 0) {
+            if (viewModel.currentStep == 2) {
+                viewModel.currentStep = 1
+            } else if (viewModel.currentStep == 1) {
+                viewModel.currentStep = 0
             }
         } else {
             navController.navigateUp()
@@ -129,20 +125,22 @@ fun HistoryTakingAndTestsScreen(
             TopAppBar(
                 title = {
                     Text(
-                        text = if (currentStep > 0) "Add ${tabs[pagerState.currentPage].lowercase()}" else stringResource(R.string.history_taking_and_tests),
+                        text = if (viewModel.currentStep > 0) "Add ${tabs[pagerState.currentPage].lowercase()}" else stringResource(
+                            R.string.history_taking_and_tests
+                        ),
                         style = MaterialTheme.typography.titleLarge
                     )
                 },
                 navigationIcon = {
-                    if (currentStep == 0) {
+                    if (viewModel.currentStep == 0) {
                         IconButton(onClick = { navController.navigateUp() }) {
                             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                         }
                     }
                 },
                 actions = {
-                    if (currentStep > 0) {
-                        IconButton(onClick = { currentStep = 0 }) {
+                    if (viewModel.currentStep > 0) {
+                        IconButton(onClick = { viewModel.currentStep = 0 }) {
                             Icon(Icons.Default.Clear, contentDescription = "Close")
                         }
                     }
@@ -153,7 +151,7 @@ fun HistoryTakingAndTestsScreen(
             )
         },
         bottomBar = {
-            if (currentStep == 0) {
+            if (viewModel.currentStep == 0) {
                 HistoryBottomAppBar(
                     pagerState,
                     coroutineScope,
@@ -161,11 +159,24 @@ fun HistoryTakingAndTestsScreen(
                     viewModel,
                     snackBarHostState,
                     context
-                ) { currentStep = 1 }
+                ) {
+                    if (viewModel.isScreeningSiteEnabled) {
+                        viewModel.currentStep = 1
+                    } else {
+                        handleAddButtonClick(
+                            viewModel = viewModel,
+                            pagerState = pagerState,
+                            coroutineScope = coroutineScope,
+                            navController = navController,
+                            snackBarHostState = snackBarHostState,
+                            context = context
+                        )
+                    }
+                }
             }
         },
         content = { paddingValues ->
-            when(currentStep) {
+            when (viewModel.currentStep) {
                 0 -> {
                     HistoryScaffoldContent(
                         tabs = tabs,
@@ -176,12 +187,17 @@ fun HistoryTakingAndTestsScreen(
                         navController = navController
                     )
                 }
+
                 1 -> RecordTypeSelectionContent(
-                    modifier = Modifier.padding(paddingValues).fillMaxSize(),
-                    selectedType = selectedType,
-                    onTypeSelected = { selectedType = it },
+                    modifier = Modifier
+                        .padding(paddingValues)
+                        .fillMaxSize(),
+                    selectedType = viewModel.selectedType,
+                    onTypeSelected = { viewModel.selectedType = it },
                     onContinueClick = {
-                        if (selectedType == RecordType.FACILITY) {
+                        if (viewModel.selectedType == RecordType.FACILITY) {
+                            viewModel.selectedCampaignId=null
+                            viewModel.getAppointmentInfo {  }
                             handleAddButtonClick(
                                 viewModel = viewModel,
                                 pagerState = pagerState,
@@ -190,18 +206,26 @@ fun HistoryTakingAndTestsScreen(
                                 snackBarHostState = snackBarHostState,
                                 context = context
                             )
-                        } else if (selectedType == RecordType.SCREENING_SITE) {
-                            currentStep = 2
+                        } else if (viewModel.selectedType == RecordType.SCREENING_SITE) {
+                            viewModel.currentStep = 2
                         }
                     }
                 )
+
                 2 -> ScreeningSiteListContent(
-                    modifier = Modifier.padding(paddingValues).fillMaxSize(),
-                    sites = SITE_LIST,
+                    modifier = Modifier
+                        .padding(paddingValues)
+                        .fillMaxSize(),
+                    sites = viewModel.screeningSites.map { it.name },
                     selectedSite = selectedSite,
-                    onSiteSelected = { selectedSite = it },
-                    onBackClick = { currentStep = 1 },
+                    onSiteSelected = { siteName ->
+                        selectedSite = siteName
+                        viewModel.selectedCampaignId =
+                            viewModel.screeningSites.find { it.name == siteName }?.id
+                    },
+                    onBackClick = { viewModel.currentStep = 1 },
                     onContinueClick = {
+                        viewModel.getAppointmentInfo { }
                         handleAddButtonClick(
                             viewModel = viewModel,
                             pagerState = pagerState,
@@ -237,17 +261,19 @@ private fun HandleLaunchedEffectsAndSnackBars(
         }
         viewModel.getPreviousRecords(viewModel.patient!!.id)
 
-        showSnackBars(navController, snackBarHostState, context)
+        showSnackBars(navController, snackBarHostState, context,viewModel)
     }
 }
 
 private suspend fun showSnackBars(
     navController: NavController,
     snackBarHostState: SnackbarHostState,
-    context: Context
+    context: Context,
+    viewModel: HistoryTakingAndTestsViewModel
 ) {
     navController.currentBackStackEntry?.savedStateHandle?.let { handle ->
         if (handle.remove<Boolean>(PRIOR_DX_SAVED) == true) {
+            viewModel.currentStep =0
             snackBarHostState.showSnackbar(context.getString(R.string.prior_dx_saved))
         }
         if (handle.remove<Boolean>(MEDICATION_SAVED) == true) {
@@ -357,7 +383,7 @@ private fun HistoryBottomAppBar(
                 viewModel = viewModel,
                 snackBarHostState = snackBarHostState,
                 context = context,
-                navController=navController,
+                navController = navController,
                 onAddClick = onAddClick
             )
 
@@ -393,17 +419,24 @@ private fun AddAssessmentButton(
                     5 -> viewModel.todayTobaccoCessation != null
                     else -> false
                 }
-                if (hasData && !viewModel.existsInOtherHospital) {
-                    handleAddButtonClick(
-                        viewModel = viewModel,
-                        pagerState = pagerState,
-                        coroutineScope = coroutineScope,
-                        navController = navController,
-                        snackBarHostState = snackBarHostState,
-                        context = context
-                    )
-                } else {
-                    onAddClick()
+                when {
+                    hasData && !viewModel.existsInOtherHospital -> {
+                        if (viewModel.isScreeningSiteEnabled) {
+                            viewModel.currentStep = 1
+                        } else {
+                            handleAddButtonClick(
+                                viewModel = viewModel,
+                                pagerState = pagerState,
+                                coroutineScope = coroutineScope,
+                                navController = navController,
+                                snackBarHostState = snackBarHostState,
+                                context = context
+                            )
+                        }
+                    }
+                    else -> {
+                        onAddClick()
+                    }
                 }
             } else {
                 coroutineScope.launch {
@@ -445,11 +478,13 @@ private fun handleAddButtonClick(
 
                 viewModel.canAddAssessment -> {
                     navigateToAddScreen(
-                        viewModel.patient!!,
+                        viewModel,
                         pagerState,
                         navController,
                         coroutineScope
                     )
+                    viewModel.currentStep = 0
+
                 }
 
                 viewModel.isAppointmentCompleted -> {
@@ -457,7 +492,24 @@ private fun handleAddButtonClick(
                 }
 
                 else -> {
-                    viewModel.showAddToQueueDialog = true
+                    if (viewModel.selectedCampaignId != null) {
+                        viewModel.addPatientToCampaignQueue(
+                            viewModel.patient!!,
+                            viewModel.selectedCampaignId!!,
+                            addedToQueue = {
+                                navigateToAddScreen(
+                                    viewModel,
+                                    pagerState,
+                                    navController,
+                                    coroutineScope
+                                )
+                                viewModel.showAddToQueueDialog = false
+
+                            }
+                        )
+                    } else {
+                        viewModel.showAddToQueueDialog = true
+                    }
                 }
             }
         }
@@ -547,13 +599,17 @@ private fun getBtnText(
 }
 
 private fun navigateToAddScreen(
-    patient: PatientResponse,
+    viewModel: HistoryTakingAndTestsViewModel,
     pagerState: PagerState,
     navController: NavController,
     coroutineScope: CoroutineScope
 ) {
     coroutineScope.launch {
-        navController.currentBackStackEntry?.savedStateHandle?.set(PATIENT, patient)
+        navController.currentBackStackEntry?.savedStateHandle?.set(PATIENT, viewModel.patient!!)
+        navController.currentBackStackEntry?.savedStateHandle?.set(
+            CAMPAIGN_ID,
+            viewModel.selectedCampaignId
+        )
         when (pagerState.currentPage) {
             0 -> navController.navigate(Screen.AddPriorDxScreen.route)
             1 -> navController.navigate(Screen.AddMedicationScreen.route)
@@ -590,7 +646,7 @@ private fun AddToQueueDialog(
                     updated = {
                         viewModel.showAddToQueueDialog = false
                         navigateToAddScreen(
-                            viewModel.patient!!,
+                            viewModel,
                             pagerState,
                             navController,
                             coroutineScope
@@ -606,7 +662,7 @@ private fun AddToQueueDialog(
                         addedToQueue = {
                             viewModel.showAddToQueueDialog = false
                             navigateToAddScreen(
-                                viewModel.patient!!,
+                                viewModel,
                                 pagerState,
                                 navController,
                                 coroutineScope

--- a/app/src/main/java/com/heartcare/agni/ui/historyandtests/HistoryTakingAndTestsViewModel.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/historyandtests/HistoryTakingAndTestsViewModel.kt
@@ -1,10 +1,13 @@
 package com.heartcare.agni.ui.historyandtests
 
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewModelScope
 import com.heartcare.agni.base.viewmodel.BaseViewModel
+import com.heartcare.agni.data.local.enums.AppointmentStatusEnum
+import com.heartcare.agni.data.local.enums.RecordType
 import com.heartcare.agni.data.local.model.appointment.AppointmentResponseLocal
 import com.heartcare.agni.data.local.repository.allergy.AllergyRepository
 import com.heartcare.agni.data.local.repository.appointment.AppointmentRepository
@@ -17,6 +20,8 @@ import com.heartcare.agni.data.local.repository.priordx.PriorDxRepository
 import com.heartcare.agni.data.local.repository.risk.RiskFactorRepository
 import com.heartcare.agni.data.local.repository.schedule.ScheduleRepository
 import com.heartcare.agni.data.local.repository.tobacco.TobaccoCessationRepository
+import com.heartcare.agni.data.local.roomdb.dao.ScreeningSiteDao
+import com.heartcare.agni.data.local.roomdb.entities.campaign.ScreeningSiteMasterEntity
 import com.heartcare.agni.data.server.model.allergy.AllergyResponse
 import com.heartcare.agni.data.server.model.family.FamilyHistoryResponse
 import com.heartcare.agni.data.server.model.historymedication.HistoryMedicationResponse
@@ -28,10 +33,12 @@ import com.heartcare.agni.di.dispatcher.IoDispatcher
 import com.heartcare.agni.utils.common.Queries
 import com.heartcare.agni.utils.common.Queries.getInProgressCompletedAppointmentIds
 import com.heartcare.agni.utils.common.Queries.loadAppointmentInfo
+import com.heartcare.agni.utils.common.Queries.loadCampaignPriorDxInfo
 import com.heartcare.agni.utils.converters.responseconverter.TimeConverter.isToday
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -47,6 +54,7 @@ class HistoryTakingAndTestsViewModel @Inject constructor(
     private val allergyRepository: AllergyRepository,
     private val riskFactorRepository: RiskFactorRepository,
     private val tobaccoCessationRepository: TobaccoCessationRepository,
+    private val screeningSiteDao: ScreeningSiteDao,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : BaseViewModel() {
     var isLaunched by mutableStateOf(false)
@@ -82,22 +90,59 @@ class HistoryTakingAndTestsViewModel @Inject constructor(
     var showAppointmentCompletedDialog by mutableStateOf(false)
     var isAppointmentCompleted by mutableStateOf(false)
     var existsInOtherHospital by mutableStateOf(false)
+    
+    var selectedCampaignId by mutableStateOf<String?>(null)
+    var screeningSites by mutableStateOf(listOf<ScreeningSiteMasterEntity>())
+    var isScreeningSiteEnabled by mutableStateOf(false)
+    var currentStep by  mutableIntStateOf(0)
+    var selectedType by mutableStateOf<RecordType?>(null)
+
+    init {
+        loadActiveScreeningSites()
+    }
+    internal fun loadActiveScreeningSites() {
+        viewModelScope.launch(ioDispatcher) {
+            val allSites = Queries.getScreeningSites(screeningSiteDao)
+            val userFhirId = user.fhirId
+            Timber.d("USERID: $userFhirId")
+            screeningSites = allSites.filter { site ->
+                site.staff.any { it.id == userFhirId }
+            }
+            isScreeningSiteEnabled = screeningSites.isNotEmpty()
+        }
+    }
 
     internal fun getAppointmentInfo(
         callback: () -> Unit
     ) {
         viewModelScope.launch(ioDispatcher) {
-            val info = loadAppointmentInfo(
-                patientId = patient!!.id,
-                hospitalCode = user.hospitalCode,
-                maxNumberOfAppointmentsInADay = maxNumberOfAppointmentsInADay,
-                appointmentRepository = appointmentRepository
-            )
-            appointment = info.appointment
-            existsInOtherHospital = info.existsInOtherHospital
-            canAddAssessment = info.canAddAssessment
-            isAppointmentCompleted = info.isAppointmentCompleted
-            ifAllSlotsBooked = info.ifAllSlotsBooked
+            val campaignId = selectedCampaignId
+            if (campaignId != null) {
+                val info = loadCampaignPriorDxInfo(
+                    patientId = patient!!.id,
+                    campaignId = campaignId,
+                    appointmentRepository = appointmentRepository,
+                    priorDxRepository = priorDxRepository
+                )
+                appointment = info.appointment
+                existsInOtherHospital = false
+                canAddAssessment = info.appointment != null
+                isAppointmentCompleted = info.appointment?.status == AppointmentStatusEnum.COMPLETED.value
+                ifAllSlotsBooked = false
+            } else {
+                // Standard Facility path
+                val info = loadAppointmentInfo(
+                    patientId = patient!!.id,
+                    hospitalCode = user.hospitalCode,
+                    maxNumberOfAppointmentsInADay = maxNumberOfAppointmentsInADay,
+                    appointmentRepository = appointmentRepository
+                )
+                appointment = info.appointment
+                existsInOtherHospital = info.existsInOtherHospital
+                canAddAssessment = info.canAddAssessment
+                isAppointmentCompleted = info.isAppointmentCompleted
+                ifAllSlotsBooked = info.ifAllSlotsBooked
+            }
             callback()
         }
     }
@@ -115,6 +160,23 @@ class HistoryTakingAndTestsViewModel @Inject constructor(
                 appointmentRepository,
                 patientLastUpdatedRepository,
                 addedToQueue
+            )
+        }
+    }
+
+    internal fun addPatientToCampaignQueue(
+        patient: PatientResponse,
+        campaignId: String,
+        addedToQueue: (List<Long>) -> Unit
+    ) {
+        viewModelScope.launch(ioDispatcher) {
+            Queries.addPatientToCampaignQueue(
+                patient = patient,
+                campaignId = campaignId,
+                scheduleRepository = scheduleRepository,
+                genericRepository = genericRepository,
+                appointmentRepository = appointmentRepository,
+                addedToQueue = addedToQueue
             )
         }
     }
@@ -140,10 +202,23 @@ class HistoryTakingAndTestsViewModel @Inject constructor(
 
     fun getPreviousRecords(patientId: String) {
         viewModelScope.launch(ioDispatcher) {
-            val appointmentIds =
-                getInProgressCompletedAppointmentIds(patientId, appointmentRepository)
-            priorDxList = priorDxRepository.getPriorDxRecordsByAppointmentIds(*appointmentIds.toTypedArray()).also {
-                todayPriorDx = it.firstOrNull { priorDx -> isToday(priorDx.createdOn!!) }
+
+            // Load all screening sites once for mapping names
+            val allSites = screeningSiteDao.getScreeningSiteMaster()
+            val siteMap = allSites.associateBy { it.id }
+
+            val appointmentIds = getInProgressCompletedAppointmentIds(patientId, appointmentRepository)
+            val screenSiteAppointmentIds = Queries.getScreenSiteAppointmentIds(patientId, appointmentRepository)
+            val allCombinedIds = (screenSiteAppointmentIds+appointmentIds).toTypedArray()
+
+            priorDxList = priorDxRepository.getPriorDxRecordsByAppointmentIds(*allCombinedIds).map {dxResponse ->
+                dxResponse.copy(screeningSiteName = dxResponse.campaignId?.let { siteMap[it]?.name })
+            }.also {
+                if (selectedType== RecordType.FACILITY) {
+                    todayPriorDx = it.firstOrNull { priorDx -> isToday(priorDx.createdOn!!) }
+                }else if (selectedCampaignId!= null) {
+                    todayPriorDx = priorDxRepository.getLatestPriorDxForCampaign(patientId, selectedCampaignId!!)
+                }
             }
             medicationList = historyMedicationRepository.getHistoryMedicationRecordsByAppointmentIds(*appointmentIds.toTypedArray()).also {
                 todayHistoryMedication = it.firstOrNull { historyMedication -> isToday(historyMedication.appUpdatedDate) }

--- a/app/src/main/java/com/heartcare/agni/ui/historyandtests/priordx/AddPriorDxScreen.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/historyandtests/priordx/AddPriorDxScreen.kt
@@ -39,6 +39,7 @@ import com.heartcare.agni.ui.common.CheckBoxRow
 import com.heartcare.agni.ui.common.OtherField
 import com.heartcare.agni.ui.theme.Black
 import com.heartcare.agni.ui.theme.White
+import com.heartcare.agni.utils.constants.NavControllerConstants
 import com.heartcare.agni.utils.constants.NavControllerConstants.PATIENT
 import com.heartcare.agni.utils.constants.NavControllerConstants.PRIOR_DX_SAVED
 import kotlinx.coroutines.launch
@@ -53,9 +54,11 @@ fun AddPriorDxScreen(
 
     LaunchedEffect(viewModel.isLaunched) {
         if (!viewModel.isLaunched) {
-            navController.previousBackStackEntry?.savedStateHandle
-                ?.get<PatientResponse>(PATIENT)?.let {
+            val handle = navController.previousBackStackEntry?.savedStateHandle
+
+            handle?.get<PatientResponse>(PATIENT)?.let {
                     viewModel.patient = it
+                    viewModel.selectedCampaignId = handle.get<String>(NavControllerConstants.CAMPAIGN_ID)
                     viewModel.getLastPriorDx(it.id)
                 }
             viewModel.isLaunched = true

--- a/app/src/main/java/com/heartcare/agni/ui/historyandtests/priordx/AddPriorDxViewModel.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/historyandtests/priordx/AddPriorDxViewModel.kt
@@ -45,6 +45,7 @@ class AddPriorDxViewModel @Inject constructor(
     val user = preferenceRepository.getUserDetails()!!
     var patient by mutableStateOf<PatientResponse?>(null)
     var appointmentResponseLocal by mutableStateOf<AppointmentResponseLocal?>(null)
+    var selectedCampaignId by mutableStateOf<String?>(null)
     var isLaunched by mutableStateOf(false)
 
     var lastPriorDx by mutableStateOf<PriorDxResponse?>(null)
@@ -56,9 +57,17 @@ class AddPriorDxViewModel @Inject constructor(
 
     fun getLastPriorDx(patientId: String) {
         viewModelScope.launch(ioDispatcher) {
-            val appointmentIds =
-                getInProgressCompletedAppointmentIds(patientId, appointmentRepository)
-            lastPriorDx = priorDxRepository.getPriorDxRecordsByAppointmentIds(*appointmentIds.toTypedArray()).firstOrNull()
+            val campaignId = selectedCampaignId
+            if (campaignId != null) {
+                // Fetch strictly for the current campaign site
+                lastPriorDx = priorDxRepository.getLatestPriorDxForCampaign(patientId, campaignId)
+            } else {
+                // Standard facility-based lookup
+                val appointmentIds =
+                    getInProgressCompletedAppointmentIds(patientId, appointmentRepository)
+                lastPriorDx = priorDxRepository.getPriorDxRecordsByAppointmentIds(*appointmentIds.toTypedArray()).firstOrNull()
+            }
+
             lastPriorDx?.let { priorDx ->
                 selectedPriorDx = mutableListOf<String>().apply {
                     if (priorDx.hasHypertension) add(PriorDiagnosis.HYPERTENSION.display)
@@ -122,7 +131,8 @@ class AddPriorDxViewModel @Inject constructor(
             patientId = patient!!.fhirId ?: patient!!.id,
             practitionerId = null,
             practitionerName = null,
-            appUpdatedDate = Date()
+            appUpdatedDate = Date(),
+            campaignId = selectedCampaignId
         )
     }
 
@@ -133,12 +143,16 @@ class AddPriorDxViewModel @Inject constructor(
             appointmentResponseLocal = getAppointment(
                 patientId = patient!!.id,
                 hospitalCode = user.hospitalCode,
+                campaignId = selectedCampaignId,
                 appointmentRepository = appointmentRepository
             )
             var uuid = UUIDBuilder.generateUUID()
             var fhirId: String? = null
             lastPriorDx?.let {
-                if (isToday(it.createdOn!!)) {
+                if (isToday(it.createdOn!!) && selectedCampaignId ==null) {
+                    uuid = it.priorDxUuid
+                    fhirId = it.priorDxFhirId
+                }else if (selectedCampaignId !=null) {
                     uuid = it.priorDxUuid
                     fhirId = it.priorDxFhirId
                 }
@@ -157,15 +171,17 @@ class AddPriorDxViewModel @Inject constructor(
                 )
             )
             genericRepository.insertPriorDxRecord(priorDxResponse.copy(createdOn = null))
-            checkAndUpdateAppointmentStatusToInProgress(
-                inProgressTime = priorDxResponse.createdOn!!,
-                patient = patient!!,
-                appointmentResponseLocal = appointmentResponseLocal!!,
-                appointmentRepository = appointmentRepository,
-                scheduleRepository = scheduleRepository,
-                genericRepository = genericRepository,
-                preferenceRepository = preferenceRepository
-            )
+            if (selectedCampaignId == null) {
+                checkAndUpdateAppointmentStatusToInProgress(
+                    inProgressTime = priorDxResponse.createdOn!!,
+                    patient = patient!!,
+                    appointmentResponseLocal = appointmentResponseLocal!!,
+                    appointmentRepository = appointmentRepository,
+                    scheduleRepository = scheduleRepository,
+                    genericRepository = genericRepository,
+                    preferenceRepository = preferenceRepository
+                )
+            }
             updatePatientLastUpdated(
                 patient!!.id,
                 patientLastUpdatedRepository,

--- a/app/src/main/java/com/heartcare/agni/ui/historyandtests/priordx/PriorDxView.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/historyandtests/priordx/PriorDxView.kt
@@ -51,6 +51,7 @@ fun PriorDxView(
                     ExpandableCard(
                         createdOn = priorDx.createdOn!!,
                         practitionerName = priorDx.practitionerName ?: "",
+                        screenSiteName = priorDx.screeningSiteName,
                         listOfItems = getListOfPriorDx(priorDx),
                         isBulleted = true
                     )

--- a/app/src/main/java/com/heartcare/agni/ui/vitalsscreen/addvitals/AddVitalsScreen.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/vitalsscreen/addvitals/AddVitalsScreen.kt
@@ -55,6 +55,7 @@ import com.heartcare.agni.ui.common.SingleFieldWithSwapUnit
 import com.heartcare.agni.ui.theme.Black
 import com.heartcare.agni.ui.theme.White
 import com.heartcare.agni.ui.vitalsscreen.components.CustomChip
+import com.heartcare.agni.utils.constants.NavControllerConstants
 import com.heartcare.agni.utils.constants.NavControllerConstants.PATIENT
 import com.heartcare.agni.utils.constants.VitalConstants.VITAL_UPDATE_OR_ADD
 import com.heartcare.agni.utils.regex.OnlyNumberRegex.onlyNumbers
@@ -72,7 +73,7 @@ fun AddVitalsScreen(
             val handle = navController.previousBackStackEntry?.savedStateHandle
             handle?.get<PatientResponse>(PATIENT)?.let {
                 viewModel.patient = it
-                viewModel.selectedCampaignId = handle.get<String>(com.heartcare.agni.utils.constants.NavControllerConstants.CAMPAIGN_ID)
+                viewModel.selectedCampaignId = handle.get<String>(NavControllerConstants.CAMPAIGN_ID)
                 viewModel.getTodayVital(it.id)
             }
             viewModel.isLaunched = true

--- a/app/src/main/java/com/heartcare/agni/ui/vitalsscreen/addvitals/AddVitalsViewModel.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/vitalsscreen/addvitals/AddVitalsViewModel.kt
@@ -223,10 +223,10 @@ class AddVitalsViewModel @Inject constructor(
                 vitalResponse.copy(
                     appointmentId = appointmentResponseLocal!!.uuid,
                     patientId = patient!!.id,
-                    practitionerName = if (selectedCampaignId==null)getFullName(
+                    practitionerName = getFullName(
                         user.firstName,
                         user.lastName
-                    ) else null,
+                    ),
                     fhirId = fhirId
                 )
             ).also {

--- a/app/src/main/java/com/heartcare/agni/utils/common/Queries.kt
+++ b/app/src/main/java/com/heartcare/agni/utils/common/Queries.kt
@@ -1,8 +1,6 @@
 package com.heartcare.agni.utils.common
 
-import com.heartcare.agni.data.local.roomdb.dao.ScreeningSiteDao
-import com.heartcare.agni.data.local.roomdb.entities.campaign.ScreeningSiteMasterEntity
-
+import androidx.annotation.Keep
 import com.heartcare.agni.data.local.enums.AppointmentStatusEnum
 import com.heartcare.agni.data.local.enums.AppointmentTypeEnum
 import com.heartcare.agni.data.local.enums.ChangeTypeEnum
@@ -13,17 +11,19 @@ import com.heartcare.agni.data.local.model.appointment.AppointmentInfo
 import com.heartcare.agni.data.local.model.appointment.AppointmentResponseLocal
 import com.heartcare.agni.data.local.model.patch.ChangeRequest
 import com.heartcare.agni.data.local.repository.appointment.AppointmentRepository
+import com.heartcare.agni.data.local.repository.cvd.records.CVDAssessmentRepository
 import com.heartcare.agni.data.local.repository.generic.GenericRepository
 import com.heartcare.agni.data.local.repository.patient.lastupdated.PatientLastUpdatedRepository
-import com.heartcare.agni.data.local.repository.cvd.records.CVDAssessmentRepository
 import com.heartcare.agni.data.local.repository.preference.PreferenceRepository
 import com.heartcare.agni.data.local.repository.schedule.ScheduleRepository
 import com.heartcare.agni.data.local.repository.vital.VitalRepository
-import com.heartcare.agni.utils.converters.responseconverter.TimeConverter.toTimeInMilli
+import com.heartcare.agni.data.local.roomdb.dao.ScreeningSiteDao
+import com.heartcare.agni.data.local.roomdb.entities.campaign.ScreeningSiteMasterEntity
 import com.heartcare.agni.data.local.roomdb.entities.patient.PatientAndIdentifierAndAppointmentEntity
 import com.heartcare.agni.data.local.roomdb.entities.patient.PatientAndIdentifierEntity
 import com.heartcare.agni.data.server.model.patient.PatientLastUpdatedResponse
 import com.heartcare.agni.data.server.model.patient.PatientResponse
+import com.heartcare.agni.data.server.model.priordx.PriorDxResponse
 import com.heartcare.agni.data.server.model.scheduleandappointment.Slot
 import com.heartcare.agni.data.server.model.scheduleandappointment.appointment.AppointmentResponse
 import com.heartcare.agni.data.server.model.scheduleandappointment.schedule.ScheduleResponse
@@ -39,6 +39,7 @@ import com.heartcare.agni.utils.converters.responseconverter.TimeConverter.toApp
 import com.heartcare.agni.utils.converters.responseconverter.TimeConverter.toCurrentTimeInMillis
 import com.heartcare.agni.utils.converters.responseconverter.TimeConverter.toEndOfDay
 import com.heartcare.agni.utils.converters.responseconverter.TimeConverter.toSlotStartTime
+import com.heartcare.agni.utils.converters.responseconverter.TimeConverter.toTimeInMilli
 import com.heartcare.agni.utils.converters.responseconverter.TimeConverter.toTodayStartDate
 import com.heartcare.agni.utils.converters.responseconverter.TimeConverter.toddMMMyyyy
 import timber.log.Timber
@@ -675,6 +676,22 @@ object Queries {
         )
     }
 
+    /** Outreach / Screening Site PriorDx Info — detects if a record exists for current campaign */
+    internal suspend fun loadCampaignPriorDxInfo(
+        patientId: String,
+        campaignId: String,
+        appointmentRepository: AppointmentRepository,
+        priorDxRepository: com.heartcare.agni.data.local.repository.priordx.PriorDxRepository
+    ): CampaignPriorDxInfo {
+        val appointment = appointmentRepository.loadAppointmentForCampaign(patientId, campaignId)
+        val existingPriorDx = priorDxRepository.getLatestPriorDxForCampaign(patientId, campaignId)
+
+        return CampaignPriorDxInfo(
+            appointment = appointment,
+            existingPriorDx = existingPriorDx,
+            hasExistingRecord = existingPriorDx != null
+        )
+    }
     /** Campaign-specific Vital Info — detects if a vital record exists within the campaign window */
     internal suspend fun loadCampaignVitalInfo(
         patientId: String,
@@ -704,8 +721,15 @@ object Queries {
 }
 
 /** Holds campaign-specific vital state returned from loadCampaignVitalInfo */
+@Keep
 data class CampaignVitalInfo(
     val appointment: AppointmentResponseLocal?,
     val existingVital: VitalResponse?,
     val hasExistingRecord: Boolean  // true = update mode; false = create new
+)
+@Keep
+data class CampaignPriorDxInfo(
+    val appointment: AppointmentResponseLocal?,
+    val existingPriorDx: PriorDxResponse?,
+    val hasExistingRecord: Boolean
 )

--- a/app/src/main/java/com/heartcare/agni/utils/converters/responseconverter/ResponseConverter.kt
+++ b/app/src/main/java/com/heartcare/agni/utils/converters/responseconverter/ResponseConverter.kt
@@ -978,7 +978,9 @@ internal fun PriorDxResponse.toPriorDxEntity(): PriorDxEntity {
     return PriorDxEntity(
         priorDxUuid = priorDxUuid,
         priorDxFhirId = priorDxFhirId,
-        appointmentId = appointmentId,
+        appointmentId = if (campaignId.isNullOrEmpty()) appointmentId else null,
+        campaignAppointmentId = if (!campaignId.isNullOrEmpty()) appointmentId else null,
+        campaignId = campaignId,
         cancer = cancer,
         createdOn = createdOn!!,
         hasAids = hasAids,
@@ -1003,12 +1005,15 @@ internal fun PriorDxResponse.toPriorDxEntity(): PriorDxEntity {
 
 suspend fun PriorDxResponse.toPriorDxEntity(
     patientDao: PatientDao,
-    appointmentDao: AppointmentDao
+    appointmentDao: AppointmentDao,
+    campaignAppointmentDao: CampaignAppointmentDao
 ): PriorDxEntity {
     return PriorDxEntity(
         priorDxUuid = priorDxUuid,
         priorDxFhirId = priorDxFhirId,
-        appointmentId = appointmentDao.getAppointmentIdByFhirId(appointmentId),
+        appointmentId = if (campaignId.isNullOrEmpty()) appointmentDao.getAppointmentIdByFhirId(appointmentId) else null,
+        campaignAppointmentId = if (!campaignId.isNullOrEmpty()) campaignAppointmentDao.getAppointmentIdByFhirId(appointmentId) else null,
+        campaignId = campaignId,
         cancer = cancer,
         createdOn = createdOn!!,
         hasAids = hasAids,
@@ -1035,7 +1040,8 @@ internal fun PriorDxEntity.toPriorDxResponse(): PriorDxResponse {
     return PriorDxResponse(
         priorDxUuid = priorDxUuid,
         priorDxFhirId = priorDxFhirId,
-        appointmentId = appointmentId,
+        appointmentId = (appointmentId ?: campaignAppointmentId)!!,
+        campaignId = campaignId,
         cancer = cancer,
         createdOn = createdOn,
         hasAids = hasAids,


### PR DESCRIPTION
## Guidelines
- It is mandatory to assign a reviewer to PR
- A Pull Request must always refer to single or related usecase. Non related usecases must not be a part of same Pull request
- If a Pull Request has mix of type of changes then the description section must point to relevent information for each type `Note : We must avoid merging multiple changes in a single PR`
  - Bug Fix : Point to all issue id's of the bugs fixed. One commit mapped to one bug id. Do not fix multiple bugs in a single commit
  - New Feature: Must point to a usecase or relevent documentation bug
  - Enhancement: Must point to a usecase or relevent documentation bug
  - Refactoring: The context of why the refactoring has been done. 

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
- Implemented module-specific campaign info patterns (loadCampaignCVInfo, loadCampaignPriorDxInfo) 
- Updated PriorDxEntity and DAO to support campaignId and campaignAppointmentId for data isolation.
- Refactored Vitals, CVD, and History Taking ViewModels to use the new unified outreach pattern and removed redundant code.
- Integrated background synchronisation for campaign-specific PriorDx records in SyncService and SyncRepository.

closes https://github.com/LatticeInnovations/LatticeOnFhirMain/issues/2044

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
For UI related change
Mobile screen config  5.0''; 1080 x 1920; 420dpi
Tablet screen config 10.1''; 800 x 1280; mdpi

| ScreenType|  GIF/Screenshot  |
|---|---|
| Mobile-potrait  |  <img src="https://user-images.githubusercontent.com/5468111/82522760-07db8900-9b48-11ea-8b7b-43ca1a0a425a.gif" width="260"> |
| Mobile-landscape   |<img src="https://user-images.githubusercontent.com/5468111/82523184-0363a000-9b49-11ea-8a92-2231a585c13c.gif" width="600">   |
-->
