### PR TITLE
[FEAT] - Implement screen-site/campaign binding in the prescription module

### DIFF
--- a/app/schemas/com.heartcare.agni.data.local.roomdb.FhirAppDatabase/3.json
+++ b/app/schemas/com.heartcare.agni.data.local.roomdb.FhirAppDatabase/3.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 3,
-    "identityHash": "6ffb6ba5f7c2c0ed0299b5ea569eec97",
+    "identityHash": "7ab0f57df53998d8ce6461cc8502a8b7",
     "entities": [
       {
         "tableName": "PatientEntity",
@@ -435,7 +435,7 @@
       },
       {
         "tableName": "PrescriptionEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `prescriptionDate` INTEGER NOT NULL, `appointmentId` TEXT NOT NULL DEFAULT 'DEFAULT_APPOINTMENT_ID', `patientId` TEXT NOT NULL, `patientFhirId` TEXT, `prescriptionFhirId` TEXT, `prescriptionType` TEXT NOT NULL DEFAULT 'DEFAULT_PRESCRIPTION_TYPE', PRIMARY KEY(`id`), FOREIGN KEY(`patientId`) REFERENCES `PatientEntity`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `prescriptionDate` INTEGER NOT NULL, `appointmentId` TEXT DEFAULT 'DEFAULT_APPOINTMENT_ID', `campaignAppointmentId` TEXT, `campaignId` TEXT, `patientId` TEXT NOT NULL, `patientFhirId` TEXT, `prescriptionFhirId` TEXT, `prescriptionType` TEXT NOT NULL DEFAULT 'DEFAULT_PRESCRIPTION_TYPE', `screeningSiteName` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`patientId`) REFERENCES `PatientEntity`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
         "fields": [
           {
             "fieldPath": "id",
@@ -453,8 +453,17 @@
             "fieldPath": "appointmentId",
             "columnName": "appointmentId",
             "affinity": "TEXT",
-            "notNull": true,
             "defaultValue": "'DEFAULT_APPOINTMENT_ID'"
+          },
+          {
+            "fieldPath": "campaignAppointmentId",
+            "columnName": "campaignAppointmentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "campaignId",
+            "columnName": "campaignId",
+            "affinity": "TEXT"
           },
           {
             "fieldPath": "patientId",
@@ -478,6 +487,11 @@
             "affinity": "TEXT",
             "notNull": true,
             "defaultValue": "'DEFAULT_PRESCRIPTION_TYPE'"
+          },
+          {
+            "fieldPath": "screeningSiteName",
+            "columnName": "screeningSiteName",
+            "affinity": "TEXT"
           }
         ],
         "primaryKey": {
@@ -513,6 +527,24 @@
             ],
             "orders": [],
             "createSql": "CREATE INDEX IF NOT EXISTS `index_PrescriptionEntity_appointmentId` ON `${TABLE_NAME}` (`appointmentId`)"
+          },
+          {
+            "name": "index_PrescriptionEntity_campaignId",
+            "unique": false,
+            "columnNames": [
+              "campaignId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PrescriptionEntity_campaignId` ON `${TABLE_NAME}` (`campaignId`)"
+          },
+          {
+            "name": "index_PrescriptionEntity_campaignAppointmentId",
+            "unique": false,
+            "columnNames": [
+              "campaignAppointmentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PrescriptionEntity_campaignAppointmentId` ON `${TABLE_NAME}` (`campaignAppointmentId`)"
           }
         ],
         "foreignKeys": [
@@ -3617,7 +3649,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6ffb6ba5f7c2c0ed0299b5ea569eec97')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7ab0f57df53998d8ce6461cc8502a8b7')"
     ]
   }
 }

--- a/app/src/main/java/com/heartcare/agni/data/local/enums/GenericTypeEnum.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/enums/GenericTypeEnum.kt
@@ -30,5 +30,6 @@ enum class GenericTypeEnum(val number: Int, val value: String) {
     CAMPAIGN_ALLERGY(27, "Campaign_Allergy_Record"),
     CAMPAIGN_RISK_FACTORS(28, "Campaign_Risk_Factor_Record"),
     CAMPAIGN_TOBACCO_CESSATION(29, "Campaign_Tobacco_Cessation_Record"),
-    CAMPAIGN_DIAGNOSIS(30, "Campaign_Diagnosis_Record");
+    CAMPAIGN_DIAGNOSIS(30, "Campaign_Diagnosis_Record"),
+    CAMPAIGN_PRESCRIPTION(31, "Campaign_Prescription_Record");
 }

--- a/app/src/main/java/com/heartcare/agni/data/local/model/prescription/PrescriptionResponseLocal.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/model/prescription/PrescriptionResponseLocal.kt
@@ -11,7 +11,9 @@ data class PrescriptionResponseLocal(
     val generatedOn: Date,
     val prescriptionId: String,
     val prescription: List<MedicationLocal>,
-    val prescriptionFhirId: String?
+    val prescriptionFhirId: String?,
+    val campaignId: String? = null,
+    val screeningSiteName: String? = null
 )
 
 @Keep

--- a/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepository.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepository.kt
@@ -40,7 +40,7 @@ interface GenericRepository {
         uuid: String = UUIDBuilder.generateUUID()
     ): Long
 
-    suspend fun updatePrescriptionFhirId()
+    suspend fun updatePrescriptionFhirId(type: GenericTypeEnum)
 
     suspend fun insertSchedule(
         scheduleResponse: ScheduleResponse,

--- a/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepositoryDatabaseTransactions.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepositoryDatabaseTransactions.kt
@@ -70,7 +70,8 @@ open class GenericRepositoryDatabaseTransactions(
     protected suspend fun insertPrescriptionGenericEntity(
         prescriptionResponse: PrescriptionResponse,
         prescriptionGenericEntity: GenericEntity?,
-        uuid: String
+        uuid: String,
+        type: GenericTypeEnum
     ): Long {
         return if (prescriptionGenericEntity != null) {
             genericDao.insertGenericEntity(
@@ -82,7 +83,7 @@ open class GenericRepositoryDatabaseTransactions(
                     id = uuid,
                     patientId = prescriptionResponse.prescriptionId!!,
                     payload = prescriptionResponse.copy(appUpdatedOn = Date()).toJson(),
-                    type = GenericTypeEnum.PRESCRIPTION,
+                    type = type,
                     syncType = SyncType.POST
                 )
             )[0]
@@ -93,7 +94,8 @@ open class GenericRepositoryDatabaseTransactions(
         prescriptionFhirId: String,
         prescriptionResponse: PrescriptionResponse,
         prescriptionGenericEntity: GenericEntity?,
-        uuid: String
+        uuid: String,
+        type: GenericTypeEnum
     ): Long {
         return if (prescriptionGenericEntity != null) {
             genericDao.insertGenericEntity(
@@ -106,7 +108,7 @@ open class GenericRepositoryDatabaseTransactions(
                     id = uuid,
                     patientId = prescriptionFhirId,
                     payload = prescriptionResponse.copy(appUpdatedOn = Date()).toJson(),
-                    type = GenericTypeEnum.PRESCRIPTION,
+                    type = type,
                     syncType = SyncType.PUT
                 )
             )[0]

--- a/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepositoryImpl.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/repository/generic/GenericRepositoryImpl.kt
@@ -68,17 +68,18 @@ class GenericRepositoryImpl @Inject constructor(
         prescriptionResponse: PrescriptionResponse,
         uuid: String
     ): Long {
+        val type = if (prescriptionResponse.campaignId != null) GenericTypeEnum.CAMPAIGN_PRESCRIPTION else GenericTypeEnum.PRESCRIPTION
         return genericDao.getGenericEntityById(
             patientId = prescriptionResponse.prescriptionId!!,
-            genericTypeEnum = GenericTypeEnum.PRESCRIPTION,
+            genericTypeEnum = type,
             syncType = SyncType.POST
         ).let { prescriptionGenericEntity ->
-            insertPrescriptionGenericEntity(prescriptionResponse, prescriptionGenericEntity, uuid)
+            insertPrescriptionGenericEntity(prescriptionResponse, prescriptionGenericEntity, uuid, type)
         }
     }
 
-    override suspend fun updatePrescriptionFhirId() {
-        genericDao.getNotSyncedData(GenericTypeEnum.PRESCRIPTION)
+    override suspend fun updatePrescriptionFhirId(type: GenericTypeEnum) {
+        genericDao.getNotSyncedData(type)
             .forEach { prescriptionGenericEntity ->
                 updateFormPrescriptionFhirIdInGenericEntity(prescriptionGenericEntity)
             }
@@ -446,12 +447,14 @@ class GenericRepositoryImpl @Inject constructor(
         prescriptionResponse: PrescriptionResponse,
         uuid: String
     ): Long {
+        val type = if (prescriptionResponse.campaignId != null) GenericTypeEnum.CAMPAIGN_PRESCRIPTION else GenericTypeEnum.PRESCRIPTION
+
         return genericDao.getGenericEntityById(
             patientId = prescriptionFhirId,
-            genericTypeEnum = GenericTypeEnum.PRESCRIPTION,
+            genericTypeEnum = type,
             syncType = SyncType.PUT
         ).let { prescriptionGenericEntity ->
-            insertPrescriptionPutGenericEntity(prescriptionFhirId, prescriptionResponse, prescriptionGenericEntity, uuid)
+            insertPrescriptionPutGenericEntity(prescriptionFhirId, prescriptionResponse, prescriptionGenericEntity, uuid,type)
         }
     }
 

--- a/app/src/main/java/com/heartcare/agni/data/local/repository/prescription/PrescriptionRepository.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/repository/prescription/PrescriptionRepository.kt
@@ -9,5 +9,6 @@ interface PrescriptionRepository {
     suspend fun insertPrescription(prescriptionResponseLocal: PrescriptionResponseLocal): Long
     suspend fun getLastPrescriptionAndMedicineByAppointmentId(vararg appointmentIds: String): List<PrescriptionAndMedicineRelation>
     suspend fun getPrescriptionByAppointmentId(appointmentId: String): List<PrescriptionResponseLocal>
+    suspend fun getLatestPrescriptionForCampaign(patientId: String, campaignId: String): PrescriptionAndMedicineRelation?
     suspend fun deletePrescriptionDirectionEntity(prescriptionDirectionsEntity: PrescriptionDirectionsEntity): Int
 }

--- a/app/src/main/java/com/heartcare/agni/data/local/repository/prescription/PrescriptionRepositoryImpl.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/repository/prescription/PrescriptionRepositoryImpl.kt
@@ -33,6 +33,13 @@ class PrescriptionRepositoryImpl @Inject constructor(
             }
     }
 
+    override suspend fun getLatestPrescriptionForCampaign(
+        patientId: String,
+        campaignId: String
+    ): PrescriptionAndMedicineRelation? {
+        return prescriptionDao.getLatestPrescriptionForCampaign(patientId, campaignId)
+    }
+
     override suspend fun deletePrescriptionDirectionEntity(prescriptionDirectionsEntity: PrescriptionDirectionsEntity): Int {
         return prescriptionDao.deletePrescriptionDirectionEntity(prescriptionDirectionsEntity)
     }

--- a/app/src/main/java/com/heartcare/agni/data/local/roomdb/dao/PrescriptionDao.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/roomdb/dao/PrescriptionDao.kt
@@ -23,11 +23,15 @@ interface PrescriptionDao {
     suspend fun insertPrescriptionMedicines(vararg prescriptionDirectionsEntity: PrescriptionDirectionsEntity): List<Long>
 
     @Transaction
-    @Query("SELECT * FROM PrescriptionEntity prescription WHERE appointmentId IN (:appointmentIds) AND prescriptionType=:prescriptionType ORDER BY prescription.prescriptionDate DESC")
+    @Query("SELECT * FROM PrescriptionEntity prescription WHERE (appointmentId IN (:appointmentIds) OR campaignAppointmentId IN (:appointmentIds)) AND prescriptionType=:prescriptionType ORDER BY prescription.prescriptionDate DESC")
     suspend fun getPastPrescriptionsByAppointmentId(
         vararg appointmentIds: String,
         prescriptionType: String = PrescriptionType.FORM.type
     ): List<PrescriptionAndMedicineRelation>
+
+    @Transaction
+    @Query("SELECT * FROM PrescriptionEntity WHERE patientId = :patientId AND campaignId = :campaignId ORDER BY prescriptionDate DESC LIMIT 1")
+    suspend fun getLatestPrescriptionForCampaign(patientId: String, campaignId: String): PrescriptionAndMedicineRelation?
 
     @Transaction
     @Query("UPDATE PrescriptionEntity SET prescriptionFhirId = :prescriptionFhirId WHERE id = :prescriptionId")

--- a/app/src/main/java/com/heartcare/agni/data/local/roomdb/entities/prescription/PrescriptionEntity.kt
+++ b/app/src/main/java/com/heartcare/agni/data/local/roomdb/entities/prescription/PrescriptionEntity.kt
@@ -11,7 +11,7 @@ import java.util.Date
 
 @Keep
 @Entity(
-    indices = [Index("patientId"), Index("patientFhirId"), Index("appointmentId")],
+    indices = [Index("patientId"), Index("patientFhirId"), Index("appointmentId"), Index("campaignId"), Index("campaignAppointmentId")],
     foreignKeys = [
         ForeignKey(
             entity = PatientEntity::class,
@@ -24,10 +24,13 @@ data class PrescriptionEntity(
     @PrimaryKey val id: String,
     val prescriptionDate: Date,
     @ColumnInfo(defaultValue = "DEFAULT_APPOINTMENT_ID")
-    val appointmentId: String,
+    val appointmentId: String?,
+    val campaignAppointmentId: String?,
+    val campaignId: String?,
     val patientId: String,
     val patientFhirId: String?,
     val prescriptionFhirId: String?,
     @ColumnInfo(defaultValue = "DEFAULT_PRESCRIPTION_TYPE")
     val prescriptionType: String,
+    val screeningSiteName: String? = null
 )

--- a/app/src/main/java/com/heartcare/agni/data/server/api/PrescriptionApiService.kt
+++ b/app/src/main/java/com/heartcare/agni/data/server/api/PrescriptionApiService.kt
@@ -1,7 +1,6 @@
 package com.heartcare.agni.data.server.api
 
 import com.heartcare.agni.base.server.BaseResponse
-import com.heartcare.agni.data.server.constants.EndPoints.MEDICATION_REQUEST
 import com.heartcare.agni.data.server.model.create.CreateResponse
 import com.heartcare.agni.data.server.model.prescription.medication.MedicationResponse
 import com.heartcare.agni.data.server.model.prescription.medication.MedicineTimeResponse
@@ -26,12 +25,14 @@ interface PrescriptionApiService {
         @Body prescriptionData: List<Any>
     ): Response<BaseResponse<List<CreateResponse>>>
 
-    @GET("Prescription")
-    suspend fun getPastPrescription(@QueryMap(encoded = true) map: Map<String, String>?): Response<BaseResponse<List<PrescriptionResponse>>>
+    @GET("{endPoint}")
+    suspend fun getPastPrescription(
+        @Path("endPoint") endPoint: String,
+        @QueryMap(encoded = true) map: Map<String, String>?): Response<BaseResponse<List<PrescriptionResponse>>>
 
     @GET("sct/medTime")
     suspend fun getMedicineTime(@QueryMap(encoded = true) map: Map<String, String>?): Response<BaseResponse<List<MedicineTimeResponse>>>
 
-    @PUT(MEDICATION_REQUEST)
-    suspend fun sendPrescriptionPut(@Body prescriptionResponses: List<PrescriptionResponse>): Response<BaseResponse<List<CreateResponse>>>
+    @PUT("{endPoint}")
+    suspend fun sendPrescriptionPut(@Path("endPoint") endPoint: String, @Body prescriptionResponses: List<PrescriptionResponse>): Response<BaseResponse<List<CreateResponse>>>
 }

--- a/app/src/main/java/com/heartcare/agni/data/server/constants/EndPoints.kt
+++ b/app/src/main/java/com/heartcare/agni/data/server/constants/EndPoints.kt
@@ -29,5 +29,6 @@ object EndPoints {
     const val CAMPAIGN_RISK_FACTORS = "campaign/riskFactor"
     const val CAMPAIGN_TOBACCO_CESSATION = "campaign/tobaccoCessation"
     const val CAMPAIGN_DIAGNOSIS = "campaign/diagnosis"
+    const val CAMPAIGN_PRESCRIPTION = "campaign/Prescription"
 
 }

--- a/app/src/main/java/com/heartcare/agni/data/server/model/prescription/prescriptionresponse/PrescriptionResponse.kt
+++ b/app/src/main/java/com/heartcare/agni/data/server/model/prescription/prescriptionresponse/PrescriptionResponse.kt
@@ -14,6 +14,8 @@ data class PrescriptionResponse(
     val prescriptionId: String?,
     val prescriptionFhirId: String?,
     val prescription: List<Medication>,
-    val appUpdatedOn: Date?
+    val appUpdatedOn: Date?,
+    val campaignId: String?,
+    val screeningSiteName: String?=null
 )
 

--- a/app/src/main/java/com/heartcare/agni/data/server/repository/sync/SyncRepository.kt
+++ b/app/src/main/java/com/heartcare/agni/data/server/repository/sync/SyncRepository.kt
@@ -65,13 +65,14 @@ interface SyncRepository {
     suspend fun getAndInsertTobaccoCessationData(offset: Int): ResponseMapper<List<TobaccoCessationResponse>>
     suspend fun getAndInsertCampaignTobaccoCessationData(offset: Int): ResponseMapper<Any>
     suspend fun getAndInsertCampaignDiagnosisData(offset: Int): ResponseMapper<List<DiagnosisResponse>>
+    suspend fun getAndInsertCampaignPrescription(patientId: String?): ResponseMapper<List<PrescriptionResponse>>
     suspend fun getAndInsertInterventionsData(offset: Int): ResponseMapper<List<InterventionResponse>>
     suspend fun getAndInsertExaminationData(offset: Int): ResponseMapper<List<ExaminationResponse>>
     suspend fun getAndInsertReferralData(offset: Int): ResponseMapper<List<ReferralResponse>>
 
     //POST
     suspend fun sendPersonPostData(): ResponseMapper<List<CreateResponse>>
-    suspend fun sendFormPrescriptionPostData(): ResponseMapper<List<CreateResponse>>
+    suspend fun sendFormPrescriptionPostData(genericTypeEnum: GenericTypeEnum, endPoint: String): ResponseMapper<List<CreateResponse>>
     suspend fun sendSchedulePostData(): ResponseMapper<List<CreateResponse>>
     suspend fun sendAppointmentPostData(genericTypeEnum: GenericTypeEnum, endPoint: String): ResponseMapper<List<CreateResponse>>
     suspend fun sendPatientLastUpdatePostData(): ResponseMapper<List<CreateResponse>>
@@ -96,7 +97,7 @@ interface SyncRepository {
     //PATCH
     suspend fun sendPersonPatchData(): ResponseMapper<List<CreateResponse>>
     suspend fun sendAppointmentPatchData(): ResponseMapper<List<CreateResponse>>
-    suspend fun sendPrescriptionPutData(): ResponseMapper<List<CreateResponse>>
+    suspend fun sendPrescriptionPutData(genericTypeEnum: GenericTypeEnum, endPoint: String): ResponseMapper<List<CreateResponse>>
     suspend fun sentInterventionPutData(): ResponseMapper<List<CreateResponse>>
     suspend fun sentExaminationPutData(): ResponseMapper<List<CreateResponse>>
 }

--- a/app/src/main/java/com/heartcare/agni/data/server/repository/sync/SyncRepositoryImpl.kt
+++ b/app/src/main/java/com/heartcare/agni/data/server/repository/sync/SyncRepositoryImpl.kt
@@ -276,7 +276,7 @@ class SyncRepositoryImpl @Inject constructor(
                         map[PATIENT_ID] =
                             listOfGenericEntity.map { it.payload }.toNoBracketAndNoSpaceString()
                         map[COUNT] = DEFAULT_MAX_COUNT_VALUE.toString()
-                        ApiResponseConverter.convert(prescriptionApiService.getPastPrescription(map))
+                        ApiResponseConverter.convert(prescriptionApiService.getPastPrescription(MEDICATION_REQUEST,map))
                             .run {
                                 when (this) {
                                     is ApiEndResponse -> {
@@ -296,6 +296,7 @@ class SyncRepositoryImpl @Inject constructor(
             } else {
                 ApiResponseConverter.convert(
                     prescriptionApiService.getPastPrescription(
+                        MEDICATION_REQUEST,
                         mapOf(
                             Pair(PATIENT_ID, patientId)
                         )
@@ -316,6 +317,75 @@ class SyncRepositoryImpl @Inject constructor(
             crashlyticsLogger.logException(
                 e,
                 "getAndInsertFormPrescription function failed.",
+                mapOf(
+                    Pair(
+                        USER_ID,
+                        preferenceRepository.getUserDetails()?.userId ?: ERROR_FETCHING_USER_DETAILS
+                    )
+                )
+            )
+            ApiErrorResponse(
+                statusCode = 0,
+                errorMessage = e.localizedMessage ?: SOMETHING_WENT_WRONG
+            )
+        }
+    }
+
+    override suspend fun getAndInsertCampaignPrescription(patientId: String?): ResponseMapper<List<PrescriptionResponse>> {
+        return try {
+            if (patientId == null) {
+                genericDao.getSameTypeGenericEntityPayload(
+                    GenericTypeEnum.FHIR_IDS_PRESCRIPTION, SyncType.POST, COUNT_VALUE
+                ).let { listOfGenericEntity ->
+                    if (listOfGenericEntity.isEmpty()) ApiEmptyResponse()
+                    else {
+                        val map = mutableMapOf<String, String>()
+                        map[PATIENT_ID] =
+                            listOfGenericEntity.map { it.payload }.toNoBracketAndNoSpaceString()
+                        map[COUNT] = DEFAULT_MAX_COUNT_VALUE.toString()
+                        ApiResponseConverter.convert(prescriptionApiService.getPastPrescription(
+                            EndPoints.CAMPAIGN_PRESCRIPTION,
+                            map))
+                            .run {
+                                when (this) {
+                                    is ApiEndResponse -> {
+                                        insertFormPrescriptions(body)
+                                        genericDao.deleteSyncPayload(listOfGenericEntity.toListOfId())
+                                        getAndInsertFormPrescription(null)
+                                    }
+
+                                    else -> {
+                                        this
+                                    }
+                                }
+
+                            }
+                    }
+                }
+            } else {
+                ApiResponseConverter.convert(
+                    prescriptionApiService.getPastPrescription(
+                        EndPoints.CAMPAIGN_PRESCRIPTION,
+                        mapOf(
+                            Pair(PATIENT_ID, patientId)
+                        )
+                    )
+                ).run {
+                    when (this) {
+                        is ApiEndResponse -> {
+                            insertFormPrescriptions(body)
+                            this
+                        }
+
+                        else -> this
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Timber.e(e, e.localizedMessage)
+            crashlyticsLogger.logException(
+                e,
+                "getAndInsertCampaignFormPrescription function failed.",
                 mapOf(
                     Pair(
                         USER_ID,
@@ -1179,20 +1249,20 @@ class SyncRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun sendFormPrescriptionPostData(): ResponseMapper<List<CreateResponse>> {
+    override suspend fun sendFormPrescriptionPostData(genericTypeEnum: GenericTypeEnum, endPoint: String): ResponseMapper<List<CreateResponse>> {
         return try {
             genericDao.getSameTypeGenericEntityPayload(
-                genericTypeEnum = GenericTypeEnum.PRESCRIPTION,
+                genericTypeEnum = genericTypeEnum,
                 syncType = SyncType.POST
             ).let { listOfGenericEntity ->
                 if (listOfGenericEntity.isEmpty()) ApiEmptyResponse()
                 else {
                     ApiResponseConverter.convert(
                         prescriptionApiService.postPrescriptionRelatedData(
-                            MEDICATION_REQUEST,
+                            endPoint,
                             listOfGenericEntity.map { prescriptionGenericEntity ->
                                 prescriptionGenericEntity.payload.fromJson<LinkedTreeMap<*, *>>()
-                                    .mapToObject(PrescriptionResponse::class.java)!!
+                                    .mapToObject(PrescriptionResponse::class.java)!!.copy(campaignId = null)
                             }
                         )
                     ).run {
@@ -1202,7 +1272,7 @@ class SyncRepositoryImpl @Inject constructor(
                                     listOfGenericEntity,
                                     body
                                 ).let { deletedRows ->
-                                    if (deletedRows > 0) sendFormPrescriptionPostData() else this
+                                    if (deletedRows > 0) sendFormPrescriptionPostData(genericTypeEnum, endPoint) else this
                                 }
                             }
 
@@ -2038,18 +2108,21 @@ class SyncRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun sendPrescriptionPutData(): ResponseMapper<List<CreateResponse>> {
+    override suspend fun sendPrescriptionPutData(genericTypeEnum: GenericTypeEnum, endPoint: String): ResponseMapper<List<CreateResponse>> {
         return try {
             genericDao.getSameTypeGenericEntityPayload(
-                genericTypeEnum = GenericTypeEnum.PRESCRIPTION, syncType = SyncType.PUT
+                genericTypeEnum = genericTypeEnum, syncType = SyncType.PUT
             ).let { listOfGenericEntity ->
                 if (listOfGenericEntity.isEmpty()) ApiEmptyResponse()
                 else {
                     ApiResponseConverter.convert(
                         prescriptionApiService.sendPrescriptionPut(
+                            endPoint,
                             listOfGenericEntity.map { prescriptionGenericEntity ->
                                 prescriptionGenericEntity.payload.fromJson<LinkedTreeMap<*, *>>()
-                                    .mapToObject(PrescriptionResponse::class.java)!!
+                                    .mapToObject(PrescriptionResponse::class.java)!!.let {
+                                        if (genericTypeEnum == GenericTypeEnum.CAMPAIGN_PRESCRIPTION) it.copy(campaignId = null) else it
+                                    }
                             }
                         )
                     ).run {
@@ -2059,7 +2132,7 @@ class SyncRepositoryImpl @Inject constructor(
                                     listOfGenericEntity,
                                     body
                                 ).let {
-                                    if (it > 0) sendPrescriptionPutData() else this
+                                    if (it > 0) sendPrescriptionPutData(genericTypeEnum, endPoint) else this
                                 }
                             }
 

--- a/app/src/main/java/com/heartcare/agni/service/sync/SyncService.kt
+++ b/app/src/main/java/com/heartcare/agni/service/sync/SyncService.kt
@@ -31,6 +31,7 @@ class SyncService(
     private lateinit var campaignScheduleDownloadJob: Deferred<ResponseMapper<Any>?>
     private lateinit var appointmentPatchJob: Deferred<ResponseMapper<Any>?>
     private lateinit var prescriptionPatchJob: Deferred<ResponseMapper<Any>?>
+    private lateinit var campaignPrescriptionPatchJob: Deferred<ResponseMapper<Any>?>
     private lateinit var interventionPatchJob: Deferred<ResponseMapper<Any>?>
     private lateinit var examinationPatchJob: Deferred<ResponseMapper<Any>?>
     private lateinit var interventionMasterDownloadJob: Deferred<ResponseMapper<Any>?>
@@ -52,6 +53,7 @@ class SyncService(
                     async { uploadPatientAndScheduleJob(logout) },
                     async { patchPatient(logout) },
                     async { patchPrescription(logout) },
+                    async { patchCampaignPrescription(logout) },
                     async { patchIntervention(logout) },
                     async { patchExamination(logout) },
                     async { uploadPatientLastUpdatedData(logout) },
@@ -241,7 +243,8 @@ class SyncService(
                     async { updateFhirIdInCampaignAllergy(logout) },
                     async { updateFhirIdInCampaignRiskFactors(logout) },
                     async { updateFhirIdInCampaignTobaccoCessation(logout) },
-                    async { updateFhirIdInCampaignDiagnosis(logout) }
+                    async { updateFhirIdInCampaignDiagnosis(logout) },
+                    async { updateFhirIdInCampaignPrescription(logout) }
                 )
 
                 // Wait for all of them to complete
@@ -253,7 +256,11 @@ class SyncService(
 
     /** Upload Form Prescription*/
     private suspend fun uploadFormPrescriptionData(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
-        return checkAuthenticationStatus(syncRepository.sendFormPrescriptionPostData(), logout)
+        return checkAuthenticationStatus(syncRepository.sendFormPrescriptionPostData(GenericTypeEnum.PRESCRIPTION, EndPoints.MEDICATION_REQUEST), logout)
+    }
+
+    private suspend fun uploadCampaignFormPrescriptionData(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
+        return checkAuthenticationStatus(syncRepository.sendFormPrescriptionPostData(GenericTypeEnum.CAMPAIGN_PRESCRIPTION, EndPoints.CAMPAIGN_PRESCRIPTION), logout)
     }
 
     /** Upload Patient Last Updated Data */
@@ -390,10 +397,29 @@ class SyncService(
     internal suspend fun patchPrescription(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
         coroutineScope {
             prescriptionPatchJob = async {
-                checkAuthenticationStatus(syncRepository.sendPrescriptionPutData(), logout)
+                checkAuthenticationStatus(
+                    syncRepository.sendPrescriptionPutData(
+                        GenericTypeEnum.PRESCRIPTION,
+                        EndPoints.MEDICATION_REQUEST
+                    ), logout
+                )
             }
         }
         return prescriptionPatchJob.await()
+    }
+
+    internal suspend fun patchCampaignPrescription(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
+        coroutineScope {
+            campaignPrescriptionPatchJob = async {
+                checkAuthenticationStatus(
+                    syncRepository.sendPrescriptionPutData(
+                        GenericTypeEnum.CAMPAIGN_PRESCRIPTION,
+                        EndPoints.CAMPAIGN_PRESCRIPTION
+                    ), logout
+                )
+            }
+        }
+        return campaignPrescriptionPatchJob.await()
     }
 
     /** Patch Intervention */
@@ -496,7 +522,12 @@ class SyncService(
                     async { downloadCampaignAllergy(logout) },
                     async { downloadCampaignRiskFactors(logout) },
                     async { downloadCampaignTobaccoCessation(logout) },
-                    async { downloadCampaignDiagnosis(logout) }
+                    async { downloadCampaignTobaccoCessation(logout) },
+                    async { downloadCampaignDiagnosis(logout) },
+                    async {
+                        campaignPrescriptionPatchJob.await()
+                        downloadCampaignFormPrescription(null, logout)
+                    }
                 )
                 jobs.awaitAll()
             }
@@ -511,6 +542,16 @@ class SyncService(
     ): ResponseMapper<Any>? {
         return checkAuthenticationStatus(
             syncRepository.getAndInsertFormPrescription(patientId),
+            logout
+        )
+    }
+
+    internal suspend fun downloadCampaignFormPrescription(
+        patientId: String?,
+        logout: (Boolean, String) -> Unit
+    ): ResponseMapper<Any>? {
+        return checkAuthenticationStatus(
+            syncRepository.getAndInsertCampaignPrescription(patientId),
             logout
         )
     }
@@ -755,9 +796,15 @@ class SyncService(
 
     /** Update Appointment FHIR ID in Prescription */
     private suspend fun updateFhirIdInPrescription(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
-        genericRepository.updatePrescriptionFhirId()
+        genericRepository.updatePrescriptionFhirId(GenericTypeEnum.PRESCRIPTION)
         /** Upload Prescription */
         return uploadFormPrescriptionData(logout)
+    }
+
+    private suspend fun updateFhirIdInCampaignPrescription(logout: (Boolean, String) -> Unit): ResponseMapper<Any>? {
+        genericRepository.updatePrescriptionFhirId(GenericTypeEnum.CAMPAIGN_PRESCRIPTION)
+        /** Upload Campaign Prescription */
+        return uploadCampaignFormPrescriptionData(logout)
     }
 
     /** Update Appointment FHIR ID in CVD */

--- a/app/src/main/java/com/heartcare/agni/ui/patientlandingscreen/PatientLandingScreenViewModel.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/patientlandingscreen/PatientLandingScreenViewModel.kt
@@ -71,7 +71,9 @@ class PatientLandingScreenViewModel @Inject constructor(
         if (CheckNetwork.isInternetAvailable(getApplication<FhirApp>().applicationContext)) {
             viewModelScope.launch(ioDispatcher) {
                 syncService.patchPrescription { _, _ -> }
+                syncService.patchCampaignPrescription { _, _ -> }
                 syncService.downloadFormPrescription(patientFhirId) { _, _ -> }
+                syncService.downloadCampaignFormPrescription(patientFhirId) { _, _ -> }
                 syncData()
             }
         }

--- a/app/src/main/java/com/heartcare/agni/ui/prescription/PrescriptionScreen.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/prescription/PrescriptionScreen.kt
@@ -51,11 +51,9 @@ import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
@@ -83,7 +81,6 @@ import com.heartcare.agni.ui.prescription.quickselect.QuickSelectScreen
 import com.heartcare.agni.ui.prescription.search.PrescriptionSearchResult
 import com.heartcare.agni.ui.prescription.search.SearchPrescription
 import com.heartcare.agni.utils.constants.NavControllerConstants.PATIENT
-import com.heartcare.agni.utils.constants.ScreenSiteConstants.SITE_LIST
 import com.heartcare.agni.utils.converters.responseconverter.medication.MedicationInfoConverter.getMedInfo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -105,9 +102,6 @@ fun PrescriptionScreen(
         viewModel.tabs.size
     }
 
-    var currentStep by remember { mutableIntStateOf(0) }
-    var selectedSite by remember { mutableStateOf<String?>(null) }
-    var selectedType by remember { mutableStateOf<RecordType?>(null) }
 
     fun handleAddPrescriptionAction(onWizardReset: () -> Unit) {
         viewModel.getAppointmentInfo(
@@ -141,14 +135,44 @@ fun PrescriptionScreen(
 
                     else -> {
                         onWizardReset()
-                        viewModel.showAddToQueueDialog = true
+                        if (viewModel.selectedCampaignId != null) {
+                            viewModel.addPatientToQueue(
+                                patient = viewModel.patient!!,
+                                campaignId = viewModel.selectedCampaignId,
+                                addedToQueue = {
+                                    if (viewModel.isReprescribing) {
+                                        saveRePrescription(
+                                            context,
+                                            viewModel,
+                                            viewModel.represcribingPrescription!!,
+                                            coroutineScope,
+                                            snackBarHostState,
+                                            pagerState
+                                        )
+                                    } else {
+                                        viewModel.setTodayData()
+                                        coroutineScope.launch {
+                                            pagerState.animateScrollToPage(1)
+                                        }
+                                    }
+                                }
+                            )
+                        } else {
+                            viewModel.showAddToQueueDialog = true
+                        }
                     }
                 }
             }
         )
     }
 
-    SetBackHandler(viewModel, navController, pagerState, coroutineScope, currentStep) { currentStep = it }
+    SetBackHandler(
+        viewModel,
+        navController,
+        pagerState,
+        coroutineScope,
+        viewModel.currentStep
+    ) { viewModel.currentStep = it }
     HandleLaunchedEffect(viewModel, navController)
 
     Scaffold(
@@ -163,79 +187,105 @@ fun PrescriptionScreen(
                 modifier = Modifier
                     .padding(it)
             ) {
-                when (currentStep) {
-                    0 -> {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxSize()
-                        ) {
-                            TabRowComposable(
-                                viewModel.tabs,
-                                pagerState
-                            ) { index ->
-                                handleTabNavigation(
-                                    index = index,
-                                    viewModel = viewModel,
-                                    pagerState = pagerState,
-                                    coroutineScope = coroutineScope,
-                                    snackBarHostState = snackBarHostState,
-                                    context = context,
-                                    onTabRequiresWizard = {
-                                        if (viewModel.todayPrescription != null && !viewModel.existsInOtherHospital) {
-                                            handleAddPrescriptionAction { currentStep = 0 }
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                ) {
+                    TabRowComposable(
+                        viewModel.tabs,
+                        pagerState
+                    ) { index ->
+                        handleTabNavigation(
+                            index = index,
+                            viewModel = viewModel,
+                            pagerState = pagerState,
+                            coroutineScope = coroutineScope,
+                            snackBarHostState = snackBarHostState,
+                            context = context,
+                            onTabRequiresWizard = {
+                                viewModel.currentStep = 0
+                                coroutineScope.launch { pagerState.animateScrollToPage(index) }
+                            }
+                        )
+                    }
+                    HorizontalPager(
+                        state = pagerState,
+                        userScrollEnabled = viewModel.canAddAssessment && viewModel.patient!!.patientDeceasedReason.isNullOrBlank()
+                    ) { index ->
+                        when (index) {
+                            0 -> PreviousPrescriptionsScreen(
+                                snackBarHostState = snackBarHostState,
+                                coroutineScope = coroutineScope,
+                                viewModel = viewModel,
+                                onRequireWizard = {
+                                    if (viewModel.isScreeningSiteEnabled) {
+                                        viewModel.currentStep = 1
+                                    } else {
+                                        handleAddPrescriptionAction { viewModel.currentStep = 3 }
+                                    }
+                                }
+                            )
+
+                            1 -> {
+                                when (viewModel.currentStep) {
+                                    0 -> {
+                                        if (viewModel.isScreeningSiteEnabled) {
+                                            viewModel.currentStep = 1
                                         } else {
-                                            currentStep = 1
+                                            viewModel.currentStep = 3
                                         }
                                     }
-                                )
-                            }
-                            HorizontalPager(
-                                state = pagerState,
-                                userScrollEnabled = viewModel.canAddAssessment && viewModel.patient!!.patientDeceasedReason.isNullOrBlank()
-                            ) { index ->
-                                when (index) {
-                                    0 -> PreviousPrescriptionsScreen(
-                                        snackBarHostState = snackBarHostState,
-                                        coroutineScope = coroutineScope,
-                                        pagerState = pagerState,
-                                        viewModel = viewModel,
-                                        onRequireWizard = {
-                                            if (viewModel.todayPrescription != null && !viewModel.existsInOtherHospital) {
-                                                handleAddPrescriptionAction { currentStep = 0 }
-                                            } else {
-                                                currentStep = 1
+
+                                    1 -> RecordTypeSelectionContent(
+                                        modifier = Modifier.fillMaxSize(),
+                                        selectedType = viewModel.selectedType,
+                                        onTypeSelected = { type-> viewModel.selectedType = type },
+                                        onContinueClick = {
+                                            viewModel.patient?.let {patient->
+                                                viewModel.getPreviousPrescription(patient.id)
+                                            }
+                                            if (viewModel.selectedType == RecordType.FACILITY) {
+                                                viewModel.selectedCampaignId = null
+                                                handleAddPrescriptionAction {
+                                                    viewModel.currentStep = 3
+                                                }
+                                            } else if (viewModel.selectedType == RecordType.SCREENING_SITE) {
+                                                viewModel.currentStep = 2
                                             }
                                         }
                                     )
 
-                                    1 -> QuickSelectScreen()
+                                    2 -> ScreeningSiteListContent(
+                                        modifier = Modifier.fillMaxSize(),
+                                        sites = viewModel.screeningSites.map {site-> site.name },
+                                        selectedSite = viewModel.screeningSites.find { selectedSite -> selectedSite.id == viewModel.selectedCampaignId }?.name,
+                                        onSiteSelected = { siteName ->
+                                            viewModel.selectedCampaignId =
+                                                viewModel.screeningSites.find { site->site.name == siteName }?.id
+                                        },
+                                        onBackClick = {
+                                            viewModel.currentStep = 1
+                                            viewModel.selectedCampaignId = null
+                                        },
+                                        onContinueClick = {
+                                            if (viewModel.selectedCampaignId != null) {
+                                                viewModel.patient?.let {patient->
+                                                    viewModel.getPreviousPrescription(patient.id)
+                                                }
+                                                handleAddPrescriptionAction {
+                                                    viewModel.currentStep = 3
+                                                }
+                                            }
+                                        }
+                                    )
+
+                                    3 -> QuickSelectScreen()
                                 }
                             }
                         }
                     }
-                    1 -> RecordTypeSelectionContent(
-                        modifier = Modifier.fillMaxSize(),
-                        selectedType = selectedType,
-                        onTypeSelected = { selectedType = it },
-                        onContinueClick = {
-                            if (selectedType == RecordType.FACILITY) {
-                                handleAddPrescriptionAction() { currentStep = 0 }
-                            } else if (selectedType == RecordType.SCREENING_SITE) {
-                                currentStep = 2
-                            }
-                        }
-                    )
-                    2 -> ScreeningSiteListContent(
-                        modifier = Modifier.fillMaxSize(),
-                        sites = SITE_LIST,
-                        selectedSite = selectedSite,
-                        onSiteSelected = { selectedSite = it },
-                        onBackClick = { currentStep = 1 },
-                        onContinueClick = {
-                            handleAddPrescriptionAction() { currentStep = 0 }
-                        }
-                    )
                 }
+
             }
         }
     )
@@ -279,6 +329,7 @@ private fun SetBackHandler(
                 if (currentStep == 2) onStepChange(1)
                 else onStepChange(0)
             }
+
             viewModel.checkedMedication != null -> {
                 viewModel.checkedMedication = null
                 viewModel.medicationToEdit = null
@@ -416,7 +467,7 @@ fun BottomNavLayout(
         contentAlignment = Alignment.BottomCenter
     ) {
         AnimatedVisibility(
-            visible = pagerState.currentPage == 1,
+            visible = pagerState.currentPage == 1 && viewModel.currentStep ==3,
             enter = expandVertically(),
             exit = shrinkVertically()
         ) {
@@ -527,6 +578,7 @@ fun BottomNavLayout(
                                             withDismissAction = true
                                         )
                                     }
+                                    viewModel.currentStep = 0
                                 }
                             },
                             modifier = Modifier
@@ -681,7 +733,14 @@ private fun PrescriptionDialogs(
         )
     }
     if (viewModel.showAddToQueueDialog) {
-        AddToQueueDialog(viewModel, pagerState, coroutineScope, context, snackBarHostState)
+        AddToQueueDialog(
+            viewModel,
+            pagerState,
+            coroutineScope,
+            context,
+            snackBarHostState,
+            viewModel.selectedCampaignId
+        )
     }
 
     if (viewModel.ifAllSlotsBooked) {
@@ -703,7 +762,8 @@ private fun AddToQueueDialog(
     pagerState: PagerState,
     coroutineScope: CoroutineScope,
     context: Context,
-    snackBarHostState: SnackbarHostState
+    snackBarHostState: SnackbarHostState,
+    campaignId: String? = null
 ) {
 
     fun onAddedSuccessfully() {
@@ -751,6 +811,7 @@ private fun AddToQueueDialog(
                 } else {
                     viewModel.addPatientToQueue(
                         patient = viewModel.patient!!,
+                        campaignId = campaignId,
                         addedToQueue = { onAddedSuccessfully() }
                     )
                 }

--- a/app/src/main/java/com/heartcare/agni/ui/prescription/PrescriptionViewModel.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/prescription/PrescriptionViewModel.kt
@@ -1,10 +1,12 @@
 package com.heartcare.agni.ui.prescription
 
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewModelScope
 import com.heartcare.agni.base.viewmodel.BaseViewModel
+import com.heartcare.agni.data.local.enums.RecordType
 import com.heartcare.agni.data.local.model.appointment.AppointmentResponseLocal
 import com.heartcare.agni.data.local.model.prescription.MedicationLocal
 import com.heartcare.agni.data.local.model.prescription.PrescriptionResponseLocal
@@ -16,9 +18,11 @@ import com.heartcare.agni.data.local.repository.patient.lastupdated.PatientLastU
 import com.heartcare.agni.data.local.repository.preference.PreferenceRepository
 import com.heartcare.agni.data.local.repository.prescription.PrescriptionRepository
 import com.heartcare.agni.data.local.repository.schedule.ScheduleRepository
+import com.heartcare.agni.data.local.repository.screeningsite.ScreeningSiteRepository
 import com.heartcare.agni.data.local.repository.search.SearchRepository
 import com.heartcare.agni.data.local.roomdb.entities.medication.MedicineTimingEntity
 import com.heartcare.agni.data.local.roomdb.entities.prescription.PrescriptionAndMedicineRelation
+import com.heartcare.agni.data.server.model.campaign.ScreeningSiteMasterResponse
 import com.heartcare.agni.data.server.model.patient.PatientResponse
 import com.heartcare.agni.data.server.model.prescription.medication.MedicationResponse
 import com.heartcare.agni.data.server.model.prescription.prescriptionresponse.Medication
@@ -52,7 +56,8 @@ class PrescriptionViewModel @Inject constructor(
     private val appointmentRepository: AppointmentRepository,
     private val scheduleRepository: ScheduleRepository,
     private val patientLastUpdatedRepository: PatientLastUpdatedRepository,
-    private val preferenceRepository: PreferenceRepository,
+    val preferenceRepository: PreferenceRepository,
+    val screeningSiteRepository: ScreeningSiteRepository,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : BaseViewModel() {
     val user = preferenceRepository.getUserDetails()!!
@@ -93,6 +98,27 @@ class PrescriptionViewModel @Inject constructor(
     var showAppointmentCompletedDialog by mutableStateOf(false)
     var isAppointmentCompleted by mutableStateOf(false)
     var existsInOtherHospital by mutableStateOf(false)
+    var isScreeningSiteEnabled by mutableStateOf(false)
+    var currentStep by mutableIntStateOf(0)
+    var screeningSites by mutableStateOf<List<ScreeningSiteMasterResponse>>(listOf())
+    var selectedCampaignId by mutableStateOf<String?>(null)
+    var selectedType by mutableStateOf<RecordType?>(null)
+
+    init {
+        getScreeningSites()
+    }
+
+    fun getScreeningSites() {
+        viewModelScope.launch(ioDispatcher) {
+            val allSites = screeningSiteRepository.getActiveScreeningSites()
+            val userFhirId = user.fhirId
+            screeningSites = allSites.filter { site ->
+                site.staff.any { it.id == userFhirId }
+            }
+            isScreeningSiteEnabled = screeningSites.isNotEmpty()
+            currentStep = 0
+        }
+    }
 
     var isReprescribing by mutableStateOf(false)
     var represcribingPrescription by mutableStateOf<PrescriptionAndMedicineRelation?>(null)
@@ -101,16 +127,41 @@ class PrescriptionViewModel @Inject constructor(
         patientId: String
     ) {
         viewModelScope.launch(ioDispatcher) {
-            val appointmentIds =
-                getInProgressCompletedAppointmentIds(patientId, appointmentRepository)
-            previousPrescriptionList =
-                prescriptionRepository.getLastPrescriptionAndMedicineByAppointmentId(*appointmentIds.toTypedArray())
-            todayPrescription =
-                previousPrescriptionList.firstOrNull { isToday(it.prescriptionEntity.prescriptionDate) }
+            val allSites = screeningSiteRepository.getScreeningSites()
+            val siteMap = allSites.associateBy { it.id }
+            val appointmentIds = getInProgressCompletedAppointmentIds(patientId, appointmentRepository)
+            val screenSiteAppointmentIds = Queries.getScreenSiteAppointmentIds(patientId, appointmentRepository)
+            val allCombinedIds = (screenSiteAppointmentIds + appointmentIds).toTypedArray()
+            
+            previousPrescriptionList = prescriptionRepository.getLastPrescriptionAndMedicineByAppointmentId(*allCombinedIds).map { relation ->
+                relation.copy(
+                    prescriptionEntity = relation.prescriptionEntity.copy(
+                        screeningSiteName = relation.prescriptionEntity.campaignId?.let { siteMap[it]?.name }
+                    )
+                )
+            }
+            todayPrescription = if (selectedCampaignId ==null) {
+                previousPrescriptionList.firstOrNull { isToday(it.prescriptionEntity.prescriptionDate) && it.prescriptionEntity.campaignId==null }
+            }else {
+                todayPrescription =null
+                selectedMedicationsList = emptyList()
+                medicationsResponseWithMedicationList = emptyList()
+                previousPrescriptionList.firstOrNull()?.prescriptionEntity?.campaignId?.let { campaignId ->
+                    if (isCampaignActive(campaignId)) {
+                        prescriptionRepository.getLatestPrescriptionForCampaign(
+                            patientId,
+                            campaignId
+                        )
+                    } else null
+                }
+            }
             setTodayData()
         }
     }
 
+    private suspend fun isCampaignActive(campaignId: String): Boolean {
+        return screeningSiteRepository.getScreeningSiteById(campaignId)?.status == "active"
+    }
     fun setTodayData() {
         todayPrescription?.let { prescription ->
             selectedMedicationsList =
@@ -147,12 +198,21 @@ class PrescriptionViewModel @Inject constructor(
         callback: () -> Unit
     ) {
         viewModelScope.launch(ioDispatcher) {
-            val info = loadAppointmentInfo(
-                patientId = patient!!.id,
-                hospitalCode = user.hospitalCode,
-                maxNumberOfAppointmentsInADay = maxNumberOfAppointmentsInADay,
-                appointmentRepository = appointmentRepository
-            )
+            val campaignId = selectedCampaignId
+            val info = if (campaignId != null) {
+                Queries.getCampaignAppointmentInfo(
+                    patientId = patient!!.id,
+                    campaignId = campaignId,
+                    appointmentRepository = appointmentRepository
+                )
+            } else {
+                loadAppointmentInfo(
+                    patientId = patient!!.id,
+                    hospitalCode = user.hospitalCode,
+                    maxNumberOfAppointmentsInADay = maxNumberOfAppointmentsInADay,
+                    appointmentRepository = appointmentRepository
+                )
+            }
             appointment = info.appointment
             existsInOtherHospital = info.existsInOtherHospital
             canAddAssessment = info.canAddAssessment
@@ -192,6 +252,7 @@ class PrescriptionViewModel @Inject constructor(
             appointmentResponseLocal = getAppointment(
                 patientId = patient!!.id,
                 hospitalCode = user.hospitalCode,
+                campaignId = selectedCampaignId,
                 appointmentRepository = appointmentRepository
             )
             var uuid = UUIDBuilder.generateUUID()
@@ -218,15 +279,17 @@ class PrescriptionViewModel @Inject constructor(
                         prescriptionFhirId = fhirId,
                         medicationsList = medicationsList
                     )
-                    checkAndUpdateAppointmentStatusToInProgress(
-                        inProgressTime = date,
-                        patient = patient!!,
-                        appointmentResponseLocal = appointmentResponseLocal!!,
-                        appointmentRepository = appointmentRepository,
-                        scheduleRepository = scheduleRepository,
-                        genericRepository = genericRepository,
-                        preferenceRepository = preferenceRepository
-                    )
+                    if (selectedCampaignId==null) {
+                        checkAndUpdateAppointmentStatusToInProgress(
+                            inProgressTime = date,
+                            patient = patient!!,
+                            appointmentResponseLocal = appointmentResponseLocal!!,
+                            appointmentRepository = appointmentRepository,
+                            scheduleRepository = scheduleRepository,
+                            genericRepository = genericRepository,
+                            preferenceRepository = preferenceRepository
+                        )
+                    }
                     updatePatientLastUpdated(
                         patient!!.id,
                         patientLastUpdatedRepository,
@@ -295,7 +358,9 @@ class PrescriptionViewModel @Inject constructor(
                         doseFormCode = it.doseFormCode
                     )
                 },
-                appointmentId = appointmentResponseLocal!!.uuid
+                appointmentId = appointmentResponseLocal!!.uuid,
+                campaignId = selectedCampaignId,
+                screeningSiteName = selectedCampaignId?.let { id -> screeningSites.find { it.id == id }?.name }
             )
         )
     }
@@ -324,7 +389,8 @@ class PrescriptionViewModel @Inject constructor(
             appointmentUuid = null,
             appointmentId = appointmentResponseLocal!!.appointmentId
                 ?: appointmentResponseLocal!!.uuid,
-            appUpdatedOn = Date()
+            appUpdatedOn = Date(),
+            campaignId = selectedCampaignId
         )
         return if (prescriptionFhirId == null) {
             genericRepository.insertPrescription(prescriptionResponse)
@@ -340,19 +406,31 @@ class PrescriptionViewModel @Inject constructor(
 
     fun addPatientToQueue(
         patient: PatientResponse,
+        campaignId: String? = null,
         addedToQueue: (List<Long>) -> Unit,
         ioDispatcher: CoroutineDispatcher = Dispatchers.IO
     ) {
         viewModelScope.launch(ioDispatcher) {
-            Queries.addPatientToQueue(
-                patient,
-                scheduleRepository,
-                genericRepository,
-                preferenceRepository,
-                appointmentRepository,
-                patientLastUpdatedRepository,
-                addedToQueue
-            )
+            if (campaignId != null) {
+                Queries.addPatientToCampaignQueue(
+                    patient,
+                    campaignId,
+                    scheduleRepository,
+                    genericRepository,
+                    appointmentRepository,
+                    addedToQueue
+                )
+            } else {
+                Queries.addPatientToQueue(
+                    patient,
+                    scheduleRepository,
+                    genericRepository,
+                    preferenceRepository,
+                    appointmentRepository,
+                    patientLastUpdatedRepository,
+                    addedToQueue
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/heartcare/agni/ui/prescription/previousprescription/PreviousPrescriptionsScreen.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/prescription/previousprescription/PreviousPrescriptionsScreen.kt
@@ -58,7 +58,6 @@ import kotlinx.coroutines.launch
 fun PreviousPrescriptionsScreen(
     snackBarHostState: SnackbarHostState,
     coroutineScope: CoroutineScope,
-    pagerState: PagerState,
     viewModel: PrescriptionViewModel = hiltViewModel(),
     onRequireWizard: () -> Unit = {}
 ) {
@@ -89,7 +88,6 @@ fun PreviousPrescriptionsScreen(
                                 && viewModel.patient!!.patientDeceasedReason.isNullOrBlank(),
                         snackBarHostState,
                         coroutineScope,
-                        pagerState,
                         onRequireWizard
                     )
                 }
@@ -105,7 +103,6 @@ fun PrescriptionCard(
     showRePrescribeBtn: Boolean,
     snackBarHostState: SnackbarHostState,
     coroutineScope: CoroutineScope,
-    pagerState: PagerState,
     onRequireWizard: () -> Unit
 ) {
     val context = LocalContext.current
@@ -138,10 +135,19 @@ fun PrescriptionCard(
                     .testTag("PREVIOUS_PRESCRIPTION_TITLE_ROW"),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(
-                    text = prescription.prescriptionEntity.prescriptionDate.toPrescriptionDate(),
-                    style = MaterialTheme.typography.bodyLarge
-                )
+                Column {
+                    Text(
+                        text = prescription.prescriptionEntity.prescriptionDate.toPrescriptionDate(),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                    prescription.prescriptionEntity.screeningSiteName?.let {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
                 Spacer(modifier = Modifier.weight(1f))
                 Icon(
                     Icons.Default.KeyboardArrowDown,

--- a/app/src/main/java/com/heartcare/agni/ui/referral/ReferralScreen.kt
+++ b/app/src/main/java/com/heartcare/agni/ui/referral/ReferralScreen.kt
@@ -1,7 +1,6 @@
 package com.heartcare.agni.ui.referral
 
 import android.content.Context
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -30,12 +29,8 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -46,19 +41,15 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.heartcare.agni.R
-import com.heartcare.agni.data.local.enums.RecordType
 import com.heartcare.agni.data.server.model.patient.PatientResponse
 import com.heartcare.agni.navigation.Screen
 import com.heartcare.agni.ui.common.AppointmentCompletedDialog
 import com.heartcare.agni.ui.common.CardWithRightArrow
 import com.heartcare.agni.ui.common.CustomDialog
-import com.heartcare.agni.ui.common.RecordTypeSelectionContent
-import com.heartcare.agni.ui.common.ScreeningSiteListContent
 import com.heartcare.agni.ui.patientlandingscreen.AllSlotsBookedDialog
 import com.heartcare.agni.utils.constants.NavControllerConstants.PATIENT
 import com.heartcare.agni.utils.constants.NavControllerConstants.REFERRAL
 import com.heartcare.agni.utils.constants.NavControllerConstants.REFERRAL_SAVED
-import com.heartcare.agni.utils.constants.ScreenSiteConstants.SITE_LIST
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -71,22 +62,6 @@ fun ReferralScreen(
     val coroutineScope = rememberCoroutineScope()
     val snackBarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
-
-    var currentStep by remember { mutableIntStateOf(0) }
-    var selectedSite by remember { mutableStateOf<String?>(null) }
-    var selectedType by remember { mutableStateOf<RecordType?>(null) }
-
-    BackHandler {
-        if (currentStep > 0) {
-            if (currentStep == 2) {
-                currentStep = 1
-            } else if (currentStep == 1) {
-                currentStep = 0
-            }
-        } else {
-            navController.navigateUp()
-        }
-    }
 
     HandleLaunchedEffect(viewModel, navController, snackBarHostState, context)
 
@@ -118,54 +93,12 @@ fun ReferralScreen(
                 modifier = Modifier
                     .padding(paddingValues)
             ) {
-                when (currentStep) {
-                    0 -> ReferralScreenContent(viewModel, navController)
-                    1 -> RecordTypeSelectionContent(
-                        modifier = Modifier.fillMaxSize(),
-                        selectedType = selectedType,
-                        onTypeSelected = { selectedType = it },
-                        onContinueClick = {
-                            if (selectedType == RecordType.FACILITY) {
-                                handleAddReferralLogic(viewModel, navController, coroutineScope, snackBarHostState, context)
-                            } else if (selectedType == RecordType.SCREENING_SITE) {
-                                currentStep = 2
-                            }
-                        }
-                    )
-                    2 -> ScreeningSiteListContent(
-                        modifier = Modifier.fillMaxSize(),
-                        sites = SITE_LIST,
-                        selectedSite = selectedSite,
-                        onSiteSelected = { selectedSite = it },
-                        onBackClick = { currentStep = 1 },
-                        onContinueClick = {
-                            handleAddReferralLogic(viewModel, navController, coroutineScope, snackBarHostState, context)
-                        }
-                    )
-                }
+                ReferralScreenContent(viewModel, navController)
             }
         },
         bottomBar = {
-            if (currentStep == 0) {
-                ReferralBottomBar(
-                    viewModel = viewModel,
-                    onClickAdd = {
-                        if (viewModel.patient!!.patientDeceasedReason.isNullOrBlank()) {
-                            if (viewModel.todayReferral != null && !viewModel.existsInOtherHospital) {
-                                handleAddReferralLogic(viewModel, navController, coroutineScope, snackBarHostState, context)
-                            } else {
-                                currentStep = 1
-                            }
-                        } else {
-                            coroutineScope.launch {
-                                snackBarHostState.showSnackbar(
-                                    context.getString(R.string.patient_deceased_error_msg)
-                                )
-                            }
-                        }
-                    }
-                )
-            }
+            ReferralBottomBar(viewModel, navController, coroutineScope, snackBarHostState, context)
+
         }
     )
     Dialogs(viewModel, navController, coroutineScope)
@@ -256,50 +189,14 @@ private fun ReferralScreenContent(
     }
 }
 
-private fun handleAddReferralLogic(
+
+@Composable
+private fun ReferralBottomBar(
     viewModel: ReferralViewModel,
     navController: NavController,
     coroutineScope: CoroutineScope,
     snackBarHostState: SnackbarHostState,
     context: Context
-) {
-    viewModel.getAppointmentInfo(
-        callback = {
-            when {
-                viewModel.existsInOtherHospital -> {
-                    coroutineScope.launch {
-                        snackBarHostState.showSnackbar(
-                            message = context.getString(R.string.appointment_exists_in_other_hospital)
-                        )
-                    }
-                }
-
-                viewModel.canAddAssessment -> {
-                    coroutineScope.launch {
-                        navController.currentBackStackEntry?.savedStateHandle?.set(
-                            PATIENT,
-                            viewModel.patient
-                        )
-                        navController.navigate(Screen.AddReferralScreen.route)
-                    }
-                }
-
-                viewModel.isAppointmentCompleted -> {
-                    viewModel.showAppointmentCompletedDialog = true
-                }
-
-                else -> {
-                    viewModel.showAddToQueueDialog = true
-                }
-            }
-        }
-    )
-}
-
-@Composable
-private fun ReferralBottomBar(
-    viewModel: ReferralViewModel,
-    onClickAdd: () -> Unit
 ) {
     Row(
         modifier = Modifier
@@ -308,7 +205,48 @@ private fun ReferralBottomBar(
             .navigationBarsPadding()
     ) {
         Button(
-            onClick = onClickAdd,
+            onClick = {
+                // navigate to add referral
+                if (viewModel.patient!!.patientDeceasedReason.isNullOrBlank()) {
+                    viewModel.getAppointmentInfo(
+                        callback = {
+                            when {
+                                viewModel.existsInOtherHospital -> {
+                                    coroutineScope.launch {
+                                        snackBarHostState.showSnackbar(
+                                            message = context.getString(R.string.appointment_exists_in_other_hospital)
+                                        )
+                                    }
+                                }
+
+                                viewModel.canAddAssessment -> {
+                                    coroutineScope.launch {
+                                        navController.currentBackStackEntry?.savedStateHandle?.set(
+                                            PATIENT,
+                                            viewModel.patient
+                                        )
+                                        navController.navigate(Screen.AddReferralScreen.route)
+                                    }
+                                }
+
+                                viewModel.isAppointmentCompleted -> {
+                                    viewModel.showAppointmentCompletedDialog = true
+                                }
+
+                                else -> {
+                                    viewModel.showAddToQueueDialog = true
+                                }
+                            }
+                        }
+                    )
+                } else {
+                    coroutineScope.launch {
+                        snackBarHostState.showSnackbar(
+                            context.getString(R.string.patient_deceased_error_msg)
+                        )
+                    }
+                }
+            },
             modifier = Modifier.fillMaxWidth()
         ) {
             Icon(

--- a/app/src/main/java/com/heartcare/agni/utils/converters/responseconverter/ResponseConverter.kt
+++ b/app/src/main/java/com/heartcare/agni/utils/converters/responseconverter/ResponseConverter.kt
@@ -245,10 +245,13 @@ internal suspend fun PrescriptionResponse.toPrescriptionEntity(
         id = prescriptionId!!,
         prescriptionDate = generatedOn,
         patientId = patientDao.getPatientIdByFhirId(patientFhirId)!!,
-        appointmentId = appointmentUuid!!,
+        appointmentId = if (campaignId==null)appointmentUuid!! else null,
+        campaignAppointmentId = if (campaignId!=null) appointmentUuid!! else null,
         patientFhirId = patientFhirId,
         prescriptionFhirId = prescriptionFhirId,
-        prescriptionType = PrescriptionType.FORM.type
+        prescriptionType = PrescriptionType.FORM.type,
+        campaignId = campaignId,
+        screeningSiteName = screeningSiteName
     )
 }
 
@@ -257,10 +260,13 @@ internal fun PrescriptionResponseLocal.toPrescriptionEntity(): PrescriptionEntit
         id = prescriptionId,
         prescriptionDate = generatedOn,
         patientId = patientId,
-        appointmentId = appointmentId,
+        appointmentId = if (campaignId.isNullOrEmpty()) appointmentId else null,
+        campaignAppointmentId = if (!campaignId.isNullOrEmpty()) appointmentId else null,
         patientFhirId = patientFhirId,
         prescriptionFhirId = prescriptionFhirId,
-        prescriptionType = PrescriptionType.FORM.type
+        prescriptionType = PrescriptionType.FORM.type,
+        campaignId = campaignId,
+        screeningSiteName = screeningSiteName
     )
 }
 
@@ -575,11 +581,13 @@ internal fun PrescriptionAndMedicineRelation.toPrescriptionResponseLocal(): Pres
     return PrescriptionResponseLocal(
         patientId = prescriptionEntity.patientId,
         patientFhirId = prescriptionEntity.patientFhirId,
-        appointmentId = prescriptionEntity.appointmentId,
+        appointmentId = if(prescriptionEntity.campaignId==null)prescriptionEntity.appointmentId!! else prescriptionEntity.campaignAppointmentId!!,
         generatedOn = prescriptionEntity.prescriptionDate,
         prescriptionId = prescriptionEntity.id,
         prescription = prescriptionDirectionAndMedicineView.map { prescriptionDirectionAndMedicineView -> prescriptionDirectionAndMedicineView.toMedicationLocal() },
-        prescriptionFhirId = prescriptionEntity.prescriptionFhirId
+        prescriptionFhirId = prescriptionEntity.prescriptionFhirId,
+        campaignId = prescriptionEntity.campaignId,
+        screeningSiteName = prescriptionEntity.screeningSiteName
     )
 }
 


### PR DESCRIPTION
## Guidelines
- It is mandatory to assign a reviewer to PR
- A Pull Request must always refer to single or related usecase. Non related usecases must not be a part of same Pull request
- If a Pull Request has mix of type of changes then the description section must point to relevent information for each type `Note : We must avoid merging multiple changes in a single PR`
  - Bug Fix : Point to all issue id's of the bugs fixed. One commit mapped to one bug id. Do not fix multiple bugs in a single commit
  - New Feature: Must point to a usecase or relevent documentation bug
  - Enhancement: Must point to a usecase or relevent documentation bug
  - Refactoring: The context of why the refactoring has been done. 

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
- Refactored PrescriptionScreen navigation to integrate the outreach selection wizard (Record Type Selection and Screening Site List) inside the Quick Select tab.
- Updated PrescriptionEntity and PrescriptionDao to support campaignAppointmentId and screeningSiteName for full persistence parity.
- Refactored ResponseConverter mappers to handle dual-appointment ID mapping and screening site name propagation.
- Updated PrescriptionViewModel to resolve campaign appointments using Queries.getCampaignAppointmentInfo and populate screeningSiteName for history resolution.
- Bound screeningSiteName to clinical history cards in PreviousPrescriptionsScreen to provide outreach context.
- also removed screen site view from referral

closes https://github.com/LatticeInnovations/LatticeOnFhirMain/issues/2047

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
For UI related change
Mobile screen config  5.0''; 1080 x 1920; 420dpi
Tablet screen config 10.1''; 800 x 1280; mdpi

| ScreenType|  GIF/Screenshot  |
|---|---|
| Mobile-potrait  |  <img src="https://user-images.githubusercontent.com/5468111/82522760-07db8900-9b48-11ea-8b7b-43ca1a0a425a.gif" width="260"> |
| Mobile-landscape   |<img src="https://user-images.githubusercontent.com/5468111/82523184-0363a000-9b49-11ea-8a92-2231a585c13c.gif" width="600">   |
-->
